### PR TITLE
signature.c: Fix and add error handling

### DIFF
--- a/include/signature.h
+++ b/include/signature.h
@@ -36,10 +36,11 @@ GBytes *cms_sign_file(const gchar *filename, const gchar *certfile, const gchar 
  *
  * @param content content to verify against signature
  * @param sig signature used to verify
+ * @param error return location for a GError, or NULL
  *
  * @return TRUE if succeeded, FALSE if failed
  */
-gboolean cms_verify(GBytes *content, GBytes *sig);
+gboolean cms_verify(GBytes *content, GBytes *sig, GError **error);
 
 
 /**

--- a/src/install.c
+++ b/src/install.c
@@ -963,7 +963,7 @@ gboolean do_install_network(const gchar *url) {
 		goto out;
 	}
 
-	res = cms_verify(manifest_data, signature_data);
+	res = cms_verify(manifest_data, signature_data, NULL);
 	if (!res) {
 		g_warning("Failed to verify manifest signature");
 		goto out;

--- a/test/signature.c
+++ b/test/signature.c
@@ -37,7 +37,7 @@ static void signature_verify(void)
 	GBytes *sig = read_file("test/openssl-ca/manifest-r1.sig", NULL);
 	g_assert_nonnull(content);
 	g_assert_nonnull(sig);
-	g_assert_true(cms_verify(content, sig));
+	g_assert_true(cms_verify(content, sig, NULL));
 	g_bytes_unref(content);
 	g_bytes_unref(sig);
 }
@@ -60,9 +60,9 @@ static void signature_loopback(void)
 		       r_context()->keypath,
 		       NULL);
 	g_assert_nonnull(sig);
-	g_assert_true(cms_verify(content, sig));
+	g_assert_true(cms_verify(content, sig, NULL));
 	((char *)g_bytes_get_data(content, NULL))[0] = 0x00;
-	g_assert_false(cms_verify(content, sig));
+	g_assert_false(cms_verify(content, sig, NULL));
 	g_bytes_unref(content);
 	g_bytes_unref(sig);
 }


### PR DESCRIPTION
signature.c: Fix and add error handling

* Added error handling for cms_file
* Added missing error reporting for in cms_verify_file() when return
  value indicated an error (led to assertion errors)
* Used literal error reporting function where possible

install: Propagate mount errors to the user

* Also fixed some error prefixing strings

