### PR TITLE
Fix and enhance manifest error handling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -69,6 +69,7 @@ TEST_LOG_COMPILER = $(top_srcdir)/tap-test
 check_PROGRAMS = \
 	test/checksum.test \
 	test/config_file.test \
+	test/manifest.test \
 	test/signature.test \
 	test/install.test \
 	test/network.test \
@@ -89,6 +90,9 @@ test_checksum_test_LDADD = librauc.la
 
 test_config_file_test_SOURCES = test/config_file.c
 test_config_file_test_LDADD = librauc.la
+
+test_manifest_test_SOURCES = test/manifest.c
+test_manifest_test_LDADD = librauc.la
 
 test_signature_test_SOURCES = test/signature.c
 test_signature_test_LDADD = librauc.la

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -247,31 +247,31 @@ free:
 static void free_image(gpointer data) {
 	RaucImage *image = (RaucImage*) data;
 
-	g_free(image->slotclass);
-	g_free(image->checksum.digest);
-	g_free(image->filename);
-	g_free(image);
+	g_clear_pointer(&image->slotclass, g_free);
+	g_clear_pointer(&image->checksum.digest, g_free);
+	g_clear_pointer(&image->filename, g_free);
+	g_clear_pointer(&image, g_free);
 }
 
 static void free_file(gpointer data) {
 	RaucFile *file = (RaucFile*) data;
 
-	g_free(file->slotclass);
-	g_free(file->destname);
-	g_free(file->checksum.digest);
-	g_free(file->filename);
-	g_free(file);
+	g_clear_pointer(&file->slotclass, g_free);
+	g_clear_pointer(&file->destname, g_free);
+	g_clear_pointer(&file->checksum.digest, g_free);
+	g_clear_pointer(&file->filename, g_free);
+	g_clear_pointer(&file, g_free);
 }
 
 void free_manifest(RaucManifest *manifest) {
 
-	g_free(manifest->update_compatible);
-	g_free(manifest->update_version);
-	g_free(manifest->keyring);
-	g_free(manifest->handler_name);
+	g_clear_pointer(&manifest->update_compatible, g_free);
+	g_clear_pointer(&manifest->update_version, g_free);
+	g_clear_pointer(&manifest->keyring, g_free);
+	g_clear_pointer(&manifest->handler_name, g_free);
 	g_list_free_full(manifest->images, free_image);
 	g_list_free_full(manifest->files, free_file);
-	g_free(manifest);
+	g_clear_pointer(&manifest, g_free);
 }
 
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -11,6 +11,10 @@
 
 #define R_MANIFEST_ERROR r_manifest_error_quark ()
 
+#define R_MANIFEST_ERROR_NO_DATA	0
+#define R_MANIFEST_ERROR_CHECKSUM	1
+#define R_MANIFEST_ERROR_COMPATIBLE	2
+
 static GQuark r_manifest_error_quark (void)
 {
   return g_quark_from_static_string ("r_manifest_error_quark");
@@ -122,7 +126,7 @@ gboolean load_manifest_mem(GBytes *mem, RaucManifest **manifest, GError **error)
 
 	data = g_bytes_get_data(mem, &length);
 	if (data == NULL) {
-		g_set_error(error, R_MANIFEST_ERROR, 2, "No data avaiable");
+		g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_ERROR_NO_DATA, "No data avaiable");
 		goto out;
 	}
 
@@ -304,7 +308,7 @@ static gboolean update_manifest_checksums(RaucManifest *manifest, const gchar *d
 
 	if (had_errors) {
 		res = FALSE;
-		g_set_error(error, R_MANIFEST_ERROR, 1, "Failed updating all checksums");
+		g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_ERROR_CHECKSUM, "Failed updating all checksums");
 	}
 
 	return res;
@@ -343,7 +347,7 @@ static gboolean verify_manifest_checksums(RaucManifest *manifest, const gchar *d
 
 	if (had_errors) {
 		res = FALSE;
-		g_set_error(error, R_MANIFEST_ERROR, 1, "Failed updating all checksums");
+		g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_ERROR_CHECKSUM, "Failed updating all checksums");
 	}
 
 	return res;
@@ -412,7 +416,7 @@ static gboolean check_compatible(RaucManifest *manifest, GError **error) {
 
 	res = (g_strcmp0(r_context()->config->system_compatible, manifest->update_compatible) == 0);
 	if (!res) {
-		g_set_error(error, R_MANIFEST_ERROR, 2,
+		g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_ERROR_COMPATIBLE,
 				"'%s' (mf) does not match '%s' (sys)",
 				manifest->update_compatible,
 				r_context()->config->system_compatible);

--- a/src/signature.c
+++ b/src/signature.c
@@ -142,6 +142,15 @@ GBytes *cms_sign(GBytes *content, const gchar *certfile, const gchar *keyfile, G
 	}
 
 	res = bytes_from_bio(outsig);
+
+	if (!res) {
+		g_set_error_literal(
+				error,
+				R_SIGNATURE_ERROR,
+				R_SIGNATURE_ERROR_UNKNOWN,
+				"Read zero bytes");
+		goto out;
+	}
 out:
 	ERR_print_errors_fp(stdout);
 	BIO_free_all(incontent);

--- a/test/broken-manifest.raucm
+++ b/test/broken-manifest.raucm
@@ -1,0 +1,13 @@
+# example update manifest
+
+[update]
+# compatible missing here!
+
+[keyring]
+archive=release.tar
+
+[handler]
+filename=custom_handler.sh
+
+[image.foo]
+bar=bazz

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -4,7 +4,6 @@
 
 #include <config_file.h>
 #include <context.h>
-#include <manifest.h>
 
 #include "utils.h"
 
@@ -51,64 +50,6 @@ static void config_file_test1(void)
 	free_config(config);
 }
 
-static void manifest_check_common(RaucManifest *rm) {
-	g_assert_nonnull(rm);
-	g_assert_cmpstr(rm->update_compatible, ==, "FooCorp Super BarBazzer");
-	g_assert_cmpstr(rm->update_version, ==, "2015.04-1");
-	g_assert_cmpstr(rm->keyring, ==, "release.tar");
-	g_assert_cmpstr(rm->handler_name, ==, "custom_handler.sh");
-	g_assert_cmpstr(rm->handler_args, ==, "--dummy1 --dummy2");
-	g_assert_nonnull(rm->images);
-
-	g_assert_cmpuint(g_list_length(rm->images), ==, 2);
-	g_assert_cmpuint(g_list_length(rm->files), ==, 2);
-
-	g_print("Update Manifest\n");
-	g_print("\tCompatible: %s\n", rm->update_compatible);
-	g_print("\tVersion:    %s\n", rm->update_version);
-	if (rm->keyring)
-		g_print("\tKeyring:    %s\n", rm->keyring);
-	if (rm->handler_name)
-		g_print("\tHandler:    %s\n\n", rm->handler_name);
-
-	for (GList *l = rm->images; l != NULL; l = l->next) {
-		RaucImage *img = l->data;
-		g_assert_nonnull(img);
-		g_assert_nonnull(img->slotclass);
-		g_assert_nonnull(img->checksum.digest);
-		g_assert_nonnull(img->filename);
-
-		g_print("\tImage:\n");
-		g_print("\t SlotClass:  %s\n", img->slotclass);
-		g_print("\t Digest:     %s\n", img->checksum.digest);
-		g_print("\t Filename:   %s\n\n", img->filename);
-	}
-
-	for (GList *l = rm->files; l != NULL; l = l->next) {
-		RaucFile *file = l->data;
-		g_assert_nonnull(file);
-		g_assert_nonnull(file->slotclass);
-		g_assert_nonnull(file->destname);
-		g_assert_nonnull(file->checksum.digest);
-		g_assert_nonnull(file->filename);
-
-		g_print("\tFile:\n");
-		g_print("\t SlotClass:  %s\n", file->slotclass);
-		g_print("\t DestName:   %s\n", file->destname);
-		g_print("\t Digest:     %s\n", file->checksum.digest);
-		g_print("\t Filename:   %s\n\n", file->filename);
-	}
-}
-
-static void config_file_test2(void)
-{
-	RaucManifest *rm;
-
-	g_assert_true(load_manifest_file("test/manifest.raucm", &rm, NULL));
-	manifest_check_common(rm);
-
-	free_manifest(rm);
-}
 
 static void config_file_test3(void)
 {
@@ -121,82 +62,6 @@ static void config_file_test3(void)
 			"e437ab217356ee47cd338be0ffe33a3cb6dc1ce679475ea59ff8a8f7f6242b27");
 
 	free_slot_status(ss);
-}
-
-static void config_file_test4(void)
-{
-	RaucManifest *rm = g_new0(RaucManifest, 1);
-	RaucImage *new_image;
-	RaucFile *new_file;
-
-	rm->update_compatible = g_strdup("BarCorp FooBazzer");
-	rm->update_version = g_strdup("2011.03-1");
-	rm->keyring = g_strdup("mykeyring.tar");
-	rm->handler_name = g_strdup("myhandler.sh");
-	rm->handler_args = g_strdup("--foo");
-
-	new_image = g_new0(RaucImage, 1);
-
-	new_image->slotclass = g_strdup("rootfs");
-	new_image->checksum.type = G_CHECKSUM_SHA256;
-	new_image->checksum.digest = g_strdup("c8af04e62bad4ab75dafd22119026e5e3943f385bdcbe7731a4938102453754c");
-	new_image->filename = g_strdup("myrootimg.ext4");
-	rm->images = g_list_append(rm->images, new_image);
-
-	new_image = g_new0(RaucImage, 1);
-
-	new_image->slotclass = g_strdup("appfs");
-	new_image->checksum.type = G_CHECKSUM_SHA256;
-	new_image->checksum.digest = g_strdup("4e7e45db749b073eda450d30c978c7e2f6035b057d3e33ac4c61d69ce5155313");
-	new_image->filename = g_strdup("myappimg.ext4");
-	rm->images = g_list_append(rm->images, new_image);
-
-	new_file = g_new0(RaucFile, 1);
-
-	new_file->slotclass = g_strdup("rootfs");
-	new_file->destname = g_strdup("vmlinuz");
-	new_file->checksum.type = G_CHECKSUM_SHA256;
-	new_file->checksum.digest = g_strdup("5ce231b9683db16623783b8bcff120c11969e8d29755f25bc87a6fae92e06741");
-	new_file->filename = g_strdup("mykernel.img");
-	rm->files = g_list_append(rm->files, new_file);
-
-	g_assert_cmpuint(g_list_length(rm->images), ==, 2);
-	g_assert_cmpuint(g_list_length(rm->files), ==, 1);
-
-	g_assert_true(save_manifest_file("test/savedmanifest.raucm", rm, NULL));
-
-	g_clear_pointer(&rm, free_manifest);
-
-	g_assert_true(load_manifest_file("test/savedmanifest.raucm", &rm, NULL));
-
-	g_assert_nonnull(rm);
-	g_assert_cmpstr(rm->update_compatible, ==, "BarCorp FooBazzer");
-	g_assert_cmpstr(rm->update_version , ==, "2011.03-1");
-	g_assert_cmpstr(rm->keyring, ==, "mykeyring.tar");
-	g_assert_cmpstr(rm->handler_name, ==, "myhandler.sh");
-	g_assert_cmpstr(rm->handler_args, ==, "--foo --dummy1 --dummy2");
-
-	g_assert_cmpuint(g_list_length(rm->images), ==, 2);
-	g_assert_cmpuint(g_list_length(rm->files), ==, 1);
-
-	for (GList *l = rm->images; l != NULL; l = l->next) {
-		RaucImage *image = (RaucImage*) l->data;
-		g_assert_nonnull(image);
-		g_assert_nonnull(image->slotclass);
-		g_assert_nonnull(image->checksum.digest);
-		g_assert_nonnull(image->filename);
-	}
-
-	for (GList *l = rm->files; l != NULL; l = l->next) {
-		RaucFile *file = l->data;
-		g_assert_nonnull(file);
-		g_assert_nonnull(file->slotclass);
-		g_assert_nonnull(file->destname);
-		g_assert_nonnull(file->checksum.digest);
-		g_assert_nonnull(file->filename);
-	}
-
-	free_manifest(rm);
 }
 
 
@@ -223,18 +88,6 @@ static void config_file_test5(void)
 	free_slot_status(ss);
 }
 
-static void config_file_test6(void)
-{
-	GBytes *data = NULL;
-	RaucManifest *rm;
-
-	data = read_file("test/manifest.raucm", NULL);
-	g_assert_true(load_manifest_mem(data, &rm, NULL));
-	manifest_check_common(rm);
-
-	free_manifest(rm);
-}
-
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "");
@@ -246,11 +99,8 @@ int main(int argc, char *argv[])
 	r_context();
 
 	g_test_add_func("/config-file/test1", config_file_test1);
-	g_test_add_func("/config-file/test2", config_file_test2);
 	g_test_add_func("/config-file/test3", config_file_test3);
-	g_test_add_func("/config-file/test4", config_file_test4);
 	g_test_add_func("/config-file/test5", config_file_test5);
-	g_test_add_func("/config-file/test6", config_file_test6);
 
 	return g_test_run ();
 }

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -1,0 +1,174 @@
+#include <stdio.h>
+#include <locale.h>
+#include <glib.h>
+
+#include <config_file.h>
+#include <context.h>
+#include <manifest.h>
+
+#include "utils.h"
+
+static void manifest_check_common(RaucManifest *rm) {
+	g_assert_nonnull(rm);
+	g_assert_cmpstr(rm->update_compatible, ==, "FooCorp Super BarBazzer");
+	g_assert_cmpstr(rm->update_version, ==, "2015.04-1");
+	g_assert_cmpstr(rm->keyring, ==, "release.tar");
+	g_assert_cmpstr(rm->handler_name, ==, "custom_handler.sh");
+	g_assert_cmpstr(rm->handler_args, ==, "--dummy1 --dummy2");
+	g_assert_nonnull(rm->images);
+
+	g_assert_cmpuint(g_list_length(rm->images), ==, 2);
+	g_assert_cmpuint(g_list_length(rm->files), ==, 2);
+
+	g_print("Update Manifest\n");
+	g_print("\tCompatible: %s\n", rm->update_compatible);
+	g_print("\tVersion:    %s\n", rm->update_version);
+	if (rm->keyring)
+		g_print("\tKeyring:    %s\n", rm->keyring);
+	if (rm->handler_name)
+		g_print("\tHandler:    %s\n\n", rm->handler_name);
+
+	for (GList *l = rm->images; l != NULL; l = l->next) {
+		RaucImage *img = l->data;
+		g_assert_nonnull(img);
+		g_assert_nonnull(img->slotclass);
+		g_assert_nonnull(img->checksum.digest);
+		g_assert_nonnull(img->filename);
+
+		g_print("\tImage:\n");
+		g_print("\t SlotClass:  %s\n", img->slotclass);
+		g_print("\t Digest:     %s\n", img->checksum.digest);
+		g_print("\t Filename:   %s\n\n", img->filename);
+	}
+
+	for (GList *l = rm->files; l != NULL; l = l->next) {
+		RaucFile *file = l->data;
+		g_assert_nonnull(file);
+		g_assert_nonnull(file->slotclass);
+		g_assert_nonnull(file->destname);
+		g_assert_nonnull(file->checksum.digest);
+		g_assert_nonnull(file->filename);
+
+		g_print("\tFile:\n");
+		g_print("\t SlotClass:  %s\n", file->slotclass);
+		g_print("\t DestName:   %s\n", file->destname);
+		g_print("\t Digest:     %s\n", file->checksum.digest);
+		g_print("\t Filename:   %s\n\n", file->filename);
+	}
+}
+
+static void config_file_test2(void)
+{
+	RaucManifest *rm;
+
+	g_assert_true(load_manifest_file("test/manifest.raucm", &rm, NULL));
+	manifest_check_common(rm);
+
+	free_manifest(rm);
+}
+
+static void config_file_test4(void)
+{
+	RaucManifest *rm = g_new0(RaucManifest, 1);
+	RaucImage *new_image;
+	RaucFile *new_file;
+
+	rm->update_compatible = g_strdup("BarCorp FooBazzer");
+	rm->update_version = g_strdup("2011.03-1");
+	rm->keyring = g_strdup("mykeyring.tar");
+	rm->handler_name = g_strdup("myhandler.sh");
+	rm->handler_args = g_strdup("--foo");
+
+	new_image = g_new0(RaucImage, 1);
+
+	new_image->slotclass = g_strdup("rootfs");
+	new_image->checksum.type = G_CHECKSUM_SHA256;
+	new_image->checksum.digest = g_strdup("c8af04e62bad4ab75dafd22119026e5e3943f385bdcbe7731a4938102453754c");
+	new_image->filename = g_strdup("myrootimg.ext4");
+	rm->images = g_list_append(rm->images, new_image);
+
+	new_image = g_new0(RaucImage, 1);
+
+	new_image->slotclass = g_strdup("appfs");
+	new_image->checksum.type = G_CHECKSUM_SHA256;
+	new_image->checksum.digest = g_strdup("4e7e45db749b073eda450d30c978c7e2f6035b057d3e33ac4c61d69ce5155313");
+	new_image->filename = g_strdup("myappimg.ext4");
+	rm->images = g_list_append(rm->images, new_image);
+
+	new_file = g_new0(RaucFile, 1);
+
+	new_file->slotclass = g_strdup("rootfs");
+	new_file->destname = g_strdup("vmlinuz");
+	new_file->checksum.type = G_CHECKSUM_SHA256;
+	new_file->checksum.digest = g_strdup("5ce231b9683db16623783b8bcff120c11969e8d29755f25bc87a6fae92e06741");
+	new_file->filename = g_strdup("mykernel.img");
+	rm->files = g_list_append(rm->files, new_file);
+
+	g_assert_cmpuint(g_list_length(rm->images), ==, 2);
+	g_assert_cmpuint(g_list_length(rm->files), ==, 1);
+
+	g_assert_true(save_manifest_file("test/savedmanifest.raucm", rm, NULL));
+
+	g_clear_pointer(&rm, free_manifest);
+
+	g_assert_true(load_manifest_file("test/savedmanifest.raucm", &rm, NULL));
+
+	g_assert_nonnull(rm);
+	g_assert_cmpstr(rm->update_compatible, ==, "BarCorp FooBazzer");
+	g_assert_cmpstr(rm->update_version , ==, "2011.03-1");
+	g_assert_cmpstr(rm->keyring, ==, "mykeyring.tar");
+	g_assert_cmpstr(rm->handler_name, ==, "myhandler.sh");
+	g_assert_cmpstr(rm->handler_args, ==, "--foo --dummy1 --dummy2");
+
+	g_assert_cmpuint(g_list_length(rm->images), ==, 2);
+	g_assert_cmpuint(g_list_length(rm->files), ==, 1);
+
+	for (GList *l = rm->images; l != NULL; l = l->next) {
+		RaucImage *image = (RaucImage*) l->data;
+		g_assert_nonnull(image);
+		g_assert_nonnull(image->slotclass);
+		g_assert_nonnull(image->checksum.digest);
+		g_assert_nonnull(image->filename);
+	}
+
+	for (GList *l = rm->files; l != NULL; l = l->next) {
+		RaucFile *file = l->data;
+		g_assert_nonnull(file);
+		g_assert_nonnull(file->slotclass);
+		g_assert_nonnull(file->destname);
+		g_assert_nonnull(file->checksum.digest);
+		g_assert_nonnull(file->filename);
+	}
+
+	free_manifest(rm);
+}
+
+
+static void config_file_test6(void)
+{
+	GBytes *data = NULL;
+	RaucManifest *rm;
+
+	data = read_file("test/manifest.raucm", NULL);
+	g_assert_true(load_manifest_mem(data, &rm, NULL));
+	manifest_check_common(rm);
+
+	free_manifest(rm);
+}
+
+int main(int argc, char *argv[])
+{
+	setlocale(LC_ALL, "");
+
+	g_test_init(&argc, &argv, NULL);
+
+	r_context_conf()->configpath = g_strdup("test/test.conf");
+	r_context_conf()->handlerextra = g_strdup("--dummy1 --dummy2");
+	r_context();
+
+	g_test_add_func("/config-file/test2", config_file_test2);
+	g_test_add_func("/config-file/test4", config_file_test4);
+	g_test_add_func("/config-file/test6", config_file_test6);
+
+	return g_test_run ();
+}


### PR DESCRIPTION
* signature.c: Add missing error set for bytes_from_bio() call

* manifest.c: provide named error codes for manifest errors

* manifest.c: Fix error handling for invalid compatible
