### PR TITLE
Fix two issues with bundle installation

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -269,6 +269,10 @@ gboolean check_bundle(const gchar *bundlename, gsize *size, GError **error) {
 	}
 
 	offset -= sigsize;
+
+	if (size)
+		*size = offset;
+
 	res = g_seekable_seek(G_SEEKABLE(bundlestream),
 			      offset, G_SEEK_SET, NULL, &ierror);
 	if (!res) {
@@ -296,9 +300,6 @@ gboolean check_bundle(const gchar *bundlename, gsize *size, GError **error) {
 		g_propagate_error(error, ierror);
 		goto out;
 	}
-
-	if (size)
-		*size = offset;
 
 	res = TRUE;
 out:

--- a/src/signature.c
+++ b/src/signature.c
@@ -159,7 +159,6 @@ gboolean cms_verify(GBytes *content, GBytes *sig, GError **error) {
 					 g_bytes_get_size(content));
 	BIO *insig = BIO_new_mem_buf((void *)g_bytes_get_data(sig, NULL),
 				     g_bytes_get_size(sig));
-	BIO *outcontent = BIO_new(BIO_s_mem());
 	gboolean res = FALSE;
 
 	if (!(store = X509_STORE_new())) {
@@ -196,7 +195,7 @@ gboolean cms_verify(GBytes *content, GBytes *sig, GError **error) {
 		goto out;
 	}
 
-	if (!CMS_verify(cms, other, store, incontent, outcontent, CMS_DETACHED)) {
+	if (!CMS_verify(cms, other, store, incontent, NULL, CMS_DETACHED)) {
 		g_set_error(
 				error,
 				R_SIGNATURE_ERROR,
@@ -210,7 +209,6 @@ out:
 	ERR_print_errors_fp(stdout);
 	BIO_free_all(incontent);
 	BIO_free_all(insig);
-	BIO_free_all(outcontent);
 	X509_STORE_free(store);
 	return res;
 }


### PR DESCRIPTION
 *  signature.c: Replaced outcontent parameter with NULL in CMS_verify()
    
    This fixes malloc issues when verifying larger files. The outcontent
    parameter was passed but not used. Passing NULL is an appropriate alternative
    as CMS_verify() replaces this by using BIO_s_null() internally.

 *  bundle.c: set size retrun parameter earlier in check_bundle()
    
    If an error occured in check_bundle() the 'size' return parameter was
    not yet set to an appropriate value, even when this was already
    available. This lead to incorrect outputs of the squashfs size.
    
    Assigning the value as soon as it is available will allow showing
    correct results in case of other failures.
