### PR TITLE
.travis.yml: Move from utopic apt repository to vivid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo apt-get install -qq autoconf automake libglib2.0-dev libssl-dev
     libcurl4-openssl-dev squashfs-tools lcov slirp
   - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/
-    utopic main restricted universe multiverse" -y
+    vivid main restricted universe multiverse" -y
   - sudo apt-get update -qq
   - sudo apt-get install user-mode-linux grub-common
   - sudo pip install cpp-coveralls


### PR DESCRIPTION
Fixes travis build fail caused by utopic universe/multiverse repositories
removed from archive.ubuntu.com