### PR TITLE
bundle info enhancements

### DIFF
--- a/include/bundle.h
+++ b/include/bundle.h
@@ -5,6 +5,7 @@
 gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError **error);
 gboolean check_bundle(const gchar *bundlename, gsize *size, GError **error);
 gboolean extract_bundle(const gchar *bundlename, const gchar *outputdir, gboolean verify, GError **error);
+gboolean extract_file_from_bundle(const gchar *bundlename, const gchar *outputdir, const gchar *file, gboolean verify, GError **error);
 
 gboolean mount_bundle(const gchar *bundlename, const gchar *mountpoint, gboolean verify, GError **error);
 gboolean umount_bundle(const gchar *bundlename, GError **error);

--- a/include/bundle.h
+++ b/include/bundle.h
@@ -4,7 +4,7 @@
 
 gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError **error);
 gboolean check_bundle(const gchar *bundlename, gsize *size, GError **error);
-gboolean extract_bundle(const gchar *bundlename, const gchar *outputdir, GError **error);
+gboolean extract_bundle(const gchar *bundlename, const gchar *outputdir, gboolean verify, GError **error);
 
-gboolean mount_bundle(const gchar *bundlename, const gchar *mountpoint, GError **error);
+gboolean mount_bundle(const gchar *bundlename, const gchar *mountpoint, gboolean verify, GError **error);
 gboolean umount_bundle(const gchar *bundlename, GError **error);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -232,7 +232,10 @@ gboolean check_bundle(const gchar *bundlename, gsize *size, GError **error) {
 	goffset offset;
 	gboolean res = FALSE;
 
-	g_assert_nonnull(r_context()->config->keyring_path);
+	if (!r_context()->config->keyring_path) {
+		g_set_error(error, G_FILE_ERROR, G_FILE_ERROR_EXIST, "No keyring file provided");
+		goto out;
+	}
 
 	g_message("Reading bundle: %s", bundlename);
 

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -309,15 +309,17 @@ out:
 	return res;
 }
 
-gboolean extract_bundle(const gchar *bundlename, const gchar *outputdir, GError **error) {
+gboolean extract_bundle(const gchar *bundlename, const gchar *outputdir, gboolean verify, GError **error) {
 	GError *ierror = NULL;
 	gsize size;
 	gboolean res = FALSE;
 
-	res = check_bundle(bundlename, &size, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
+	if (verify) {
+		res = check_bundle(bundlename, &size, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
 	}
 
 	res = unsquashfs(bundlename, outputdir, &ierror);
@@ -331,15 +333,17 @@ out:
 	return res;
 }
 
-gboolean mount_bundle(const gchar *bundlename, const gchar *mountpoint, GError **error) {
+gboolean mount_bundle(const gchar *bundlename, const gchar *mountpoint, gboolean verify, GError **error) {
 	GError *ierror = NULL;
 	gsize size;
 	gboolean res = FALSE;
 
-	res = check_bundle(bundlename, &size, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
+	if (verify) {
+		res = check_bundle(bundlename, &size, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
 	}
 
 	res = r_mount_loop(bundlename, mountpoint, size, &ierror);

--- a/src/install.c
+++ b/src/install.c
@@ -1051,7 +1051,7 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error) {
 	// TODO: mount info in context ?
 	g_message("Mounting bundle '%s' to '%s'\n", bundlefile, mountpoint);
 	install_args_update(args, "Checking and mounting bundle...");
-	res = mount_bundle(bundlefile, mountpoint, &ierror);
+	res = mount_bundle(bundlefile, mountpoint, TRUE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <glib.h>
+#include <glib/gstdio.h>
 #include <gio/gio.h>
 
 #include <config.h>
@@ -226,9 +227,13 @@ out:
 
 static gboolean info_start(int argc, char **argv)
 {
-	gsize size;
-
-	g_message("info start");
+	gchar* tmpdir = NULL;
+	gchar* bundledir = NULL;
+	gchar* manifestpath = NULL;
+	RaucManifest *manifest = NULL;
+	GError *error = NULL;
+	gboolean res = FALSE;
+	gint cnt = 0;
 
 	if (argc != 3) {
 		g_warning("a file name must be provided");
@@ -238,15 +243,56 @@ static gboolean info_start(int argc, char **argv)
 
 	g_message("checking manifest for: %s", argv[2]);
 
-	if (!check_bundle(argv[2], &size, NULL)) {
-		g_warning("signature invalid (squashfs size: %"G_GSIZE_FORMAT")", size);
-		r_exit_status = 1;
+	tmpdir = g_dir_make_tmp("bundle-XXXXXX", NULL);
+	bundledir = g_build_filename(tmpdir, "bundle-content", NULL);
+	manifestpath = g_build_filename(bundledir, "manifest.raucm", NULL);
+
+	res = extract_file_from_bundle(argv[2], bundledir, "manifest.raucm", TRUE, &error);
+	if (!res) {
+		g_warning("%s", error->message);
+		g_clear_error(&error);
+ 		goto out;
+ 	}
+
+
+	res = load_manifest_file(manifestpath, &manifest, &error);
+	if (!res) {
+		g_warning("%s", error->message);
+		g_clear_error(&error);
 		goto out;
 	}
 
-	g_message("signature correct (squashfs size: %"G_GSIZE_FORMAT")", size);
+	g_message("Compatible String:\t'%s'", manifest->update_compatible);
+
+	cnt = g_list_length(manifest->images);
+	g_message("%d Image%s%s", cnt, cnt == 1 ? "" : "s", cnt > 0 ? ":" : "");
+	cnt = 0;
+	for (GList *l = manifest->images; l != NULL; l = l->next) {
+		RaucImage *img = l->data;
+		g_message("(%d)\t%s", ++cnt, img->filename);
+		g_message("\tSlotclass: %s", img->slotclass);
+		g_message("\tChecksum:  %s", img->checksum.digest);
+	}
+
+	cnt = g_list_length(manifest->files);
+	g_message("%d File%s%s", cnt, cnt == 1 ? "" : "s", cnt > 0 ? ":" : "");
+	cnt = 0;
+	for (GList *l = manifest->files; l != NULL; l = l->next) {
+		RaucFile *file = l->data;
+		g_message("(%d)\t%s", ++cnt, file->filename);
+		g_message("\tSlotclass: %s", file->slotclass);
+		g_message("\tDest: 	%s", file->destname);
+		g_message("\tChecksum:  %s", file->checksum.digest);
+	}
 
 out:
+	r_exit_status = res ? 0 : 1;
+	if (tmpdir)
+		g_rmdir(tmpdir);
+
+	g_clear_pointer(&tmpdir, g_free);
+	g_clear_pointer(&bundledir, g_free);
+	g_clear_pointer(&manifestpath, g_free);
 	return TRUE;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -17,6 +17,8 @@
 GMainLoop *r_loop = NULL;
 int r_exit_status = 0;
 
+gboolean info_noverify = FALSE;
+
 static gboolean install_notify(gpointer data) {
 	RaucInstallArgs *args = data;
 
@@ -247,7 +249,7 @@ static gboolean info_start(int argc, char **argv)
 	bundledir = g_build_filename(tmpdir, "bundle-content", NULL);
 	manifestpath = g_build_filename(bundledir, "manifest.raucm", NULL);
 
-	res = extract_file_from_bundle(argv[2], bundledir, "manifest.raucm", TRUE, &error);
+	res = extract_file_from_bundle(argv[2], bundledir, "manifest.raucm", !info_noverify, &error);
 	if (!res) {
 		g_warning("%s", error->message);
 		g_clear_error(&error);
@@ -410,8 +412,14 @@ typedef struct {
 	const gchar* name;
 	const gchar* usage;
 	gboolean (*cmd_handler) (int argc, char **argv);
+	GOptionGroup* options;
 	gboolean while_busy;
 } RaucCommand;
+
+GOptionEntry entries_info[] = {
+	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &info_noverify, "disable bundle verification", NULL},
+	{0}
+};
 
 static void cmdline_handler(int argc, char **argv)
 {
@@ -430,26 +438,31 @@ static void cmdline_handler(int argc, char **argv)
 		{"help", 'h', 0, G_OPTION_ARG_NONE, &help, NULL, NULL},
 		{0}
 	};
+	GOptionGroup *info_group = g_option_group_new("info", "Info options:", "help dummy", NULL, NULL);
+
 	GError *error = NULL;
 	gchar *text;
 
 	RaucCommand rcommands[] = {
-		{UNKNOWN, "help", "<COMMAND>", unknown_start, TRUE},
-		{INSTALL, "install", "install <BUNDLE>", install_start, FALSE},
-		{BUNDLE, "bundle", "bundle <FILE>", bundle_start, FALSE},
-		{CHECKSUM, "checksum", "checksum <DIRECTORY>", checksum_start, FALSE},
-		{INFO, "info", "info <FILE>", info_start, FALSE},
-		{STATUS, "status", "status", status_start, TRUE},
+		{UNKNOWN, "help", "<COMMAND>", unknown_start, NULL, TRUE},
+		{INSTALL, "install", "install <BUNDLE>", install_start, NULL, FALSE},
+		{BUNDLE, "bundle", "bundle <FILE>", bundle_start, NULL, FALSE},
+		{CHECKSUM, "checksum", "checksum <DIRECTORY>", checksum_start, NULL, FALSE},
+		{INFO, "info", "info <FILE>", info_start, info_group, FALSE},
+		{STATUS, "status", "status", status_start, NULL, TRUE},
 #if ENABLE_SERVICE == 1
-		{SERVICE, "service", "service", service_start, TRUE},
+		{SERVICE, "service", "service", service_start, NULL, TRUE},
 #endif
 		{0}
 	};
 	RaucCommand *rc;
 	RaucCommand *rcommand = NULL;
 
+	g_option_group_add_entries(info_group, entries_info);
+
 	context = g_option_context_new("<COMMAND>");
 	g_option_context_set_help_enabled(context, FALSE);
+	g_option_context_set_ignore_unknown_options(context, TRUE);
 	g_option_context_add_main_entries(context, entries, NULL);
 	g_option_context_set_description(context, 
 			"List of rauc commands:\n" \
@@ -513,6 +526,16 @@ static void cmdline_handler(int argc, char **argv)
 	context = g_option_context_new(rcommand->usage);
 	g_option_context_set_help_enabled(context, FALSE);
 	g_option_context_add_main_entries(context, entries, NULL);
+	if (rcommand->options)
+		g_option_context_add_group(context, rcommand->options);
+
+	/* parse command-specific options */
+	if (!g_option_context_parse(context, &argc, &argv, &error)) {
+		g_printerr("%s\n", error->message);
+		g_error_free(error);
+		r_exit_status = 1;
+		goto print_help;
+	}
 
 	if (help) {
 		goto print_help;

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -52,7 +52,7 @@ static void bundle_test1(BundleFixture *fixture,
 
 	g_assert_true(update_manifest(contentdir, FALSE, NULL));
 	g_assert_true(create_bundle(bundlename, contentdir, NULL));
-	g_assert_true(extract_bundle(bundlename, outputdir, NULL));
+	g_assert_true(extract_bundle(bundlename, outputdir, TRUE, NULL));
 	g_assert_true(verify_manifest(outputdir, NULL, FALSE, NULL));
 }
 
@@ -72,7 +72,7 @@ static void bundle_test2(BundleFixture *fixture,
 
 	g_assert_true(update_manifest(contentdir, FALSE, NULL));
 	g_assert_true(create_bundle(bundlename, contentdir, NULL));
-	g_assert_true(mount_bundle(bundlename, mountpoint, NULL));
+	g_assert_true(mount_bundle(bundlename, mountpoint, FALSE, NULL));
 	g_assert_true(verify_manifest(mountpoint, NULL, FALSE, NULL));
 	g_assert_true(umount_bundle(bundlename, NULL));
 }


### PR DESCRIPTION
Note: This patch stack is based on the command line handling patch stack

* `rauc info` shows more details of a bundle (manifest)
* Only the manifest file is extracted from squashfs, to save disk space
* Option `--no-verify` allows to check bundles without certificate check

Example output of `./rauc info --no-verify test/good-bundle.raucb`:

    ** Message: checking manifest for: test/good-bundle.raucb
    ** Message: system config not found, using default values
    ** Message: Compatible String:	'Test Config'
    ** Message: 2 Images:
    ** Message: (1)	rootfs.img
    ** Message: 	Slotclass: rootfs
    ** Message: 	Checksum:  de2f256064a0af797747c2b97505dc0b9f3df0de4f489eac731c23ae9ca9cc31
    ** Message: (2)	appfs.img
    ** Message: 	Slotclass: appfs
    ** Message: 	Checksum:  c35020473aed1b4642cd726cad727b63fff2824ad68cedd7ffb73c7cbd890479
    ** Message: 0 Files
