### PR TITLE
install.c: add handling for barebox bootstate commandline parameter

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -64,6 +64,18 @@ static const gchar* get_cmdline_bootname(void) {
 	g_clear_pointer(&match, g_match_info_free);
 	g_clear_pointer(&regex, g_regex_unref);
 
+	/* For barebox, we check if the bootstate code set the active slot name
+	 * in the command line */
+	if (g_strcmp0(r_context()->config->system_bootloader, "barebox") == 0) {
+		regex = g_regex_new("bootstate\\.active=(\\S+)", 0, 0, NULL);
+		if (g_regex_match(regex, contents, 0, &match)) {
+			bootname = g_match_info_fetch(match, 1);
+			goto out;
+		}
+		g_clear_pointer(&match, g_match_info_free);
+		g_clear_pointer(&regex, g_regex_unref);
+	}
+
 	regex = g_regex_new("root=(\\S+)", 0, 0, NULL);
 	if (g_regex_match(regex, contents, 0, &match)) {
 		bootname = g_match_info_fetch(match, 1);

--- a/test/install.c
+++ b/test/install.c
@@ -257,7 +257,8 @@ static void install_fixture_tear_down(InstallFixture *fixture,
 	test_umount(fixture->tmpdir, "slot");
 }
 
-static void install_test_bootname(void)
+static void install_test_bootname(InstallFixture *fixture,
+		gconstpointer user_data)
 {
 	g_assert_nonnull(get_bootname());
 }
@@ -438,7 +439,9 @@ int main(int argc, char *argv[])
 
 	g_test_init(&argc, &argv, NULL);
 
-	g_test_add_func("/install/bootname", install_test_bootname);
+	g_test_add("/install/bootname", InstallFixture, NULL,
+		   install_fixture_set_up, install_test_bootname,
+		   install_fixture_tear_down);
 
 	g_test_add("/install/target", InstallFixture, NULL,
 		   install_fixture_set_up, install_test_target,


### PR DESCRIPTION
barebox bootstate sets the selected boot target vi kernel commandline
parameter `bootstate.active`. This is now used to determine the boot
slot if `bootloader=barebox` was selected in the system.conf.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>