### PR TITLE
tests: set locale to "C" to fix warning message tests

### DIFF
--- a/test/bundle.c
+++ b/test/bundle.c
@@ -151,7 +151,7 @@ static void bundle_test3(BundleFixture *fixture,
 
 int main(int argc, char *argv[])
 {
-	setlocale(LC_ALL, "");
+	setlocale(LC_ALL, "C");
 
 	r_context_conf()->configpath = g_strdup("test/test.conf");
 	r_context_conf()->certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");

--- a/test/checksum.c
+++ b/test/checksum.c
@@ -64,7 +64,7 @@ static void checksum_test1(void)
 
 int main(int argc, char *argv[])
 {
-	setlocale(LC_ALL, "");
+	setlocale(LC_ALL, "C");
 
 	g_test_init(&argc, &argv, NULL);
 

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -93,7 +93,7 @@ static void config_file_test5(void)
 
 int main(int argc, char *argv[])
 {
-	setlocale(LC_ALL, "");
+	setlocale(LC_ALL, "C");
 
 	g_test_init(&argc, &argv, NULL);
 

--- a/test/install.c
+++ b/test/install.c
@@ -431,7 +431,7 @@ static void install_test_network_thread(InstallFixture *fixture,
 int main(int argc, char *argv[])
 {
 	gchar *path;
-	setlocale(LC_ALL, "");
+	setlocale(LC_ALL, "C");
 
 	path = g_strdup_printf("%s:%s", g_getenv("PATH"), "test/bin");
 	g_setenv("PATH", path, TRUE);

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -168,7 +168,7 @@ static void test_load_manifest_mem(void)
 
 int main(int argc, char *argv[])
 {
-	setlocale(LC_ALL, "");
+	setlocale(LC_ALL, "C");
 
 	g_test_init(&argc, &argv, NULL);
 

--- a/test/network.c
+++ b/test/network.c
@@ -66,7 +66,7 @@ static void test_download_mem(void)
 
 int main(int argc, char *argv[])
 {
-	setlocale(LC_ALL, "");
+	setlocale(LC_ALL, "C");
 
 	r_context_conf()->configpath = g_strdup("test/test.conf");
 	r_context();

--- a/test/signature.c
+++ b/test/signature.c
@@ -146,7 +146,7 @@ static void signature_loopback(void)
 
 int main(int argc, char *argv[])
 {
-	setlocale(LC_ALL, "");
+	setlocale(LC_ALL, "C");
 
 	r_context_conf()->configpath = g_strdup("test/test.conf");
 	r_context_conf()->certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");


### PR DESCRIPTION
Otherwise locale is set to the current system locale, which will result
in making tests for expected warning messages fail as the string
comparison will not match.