### PR TITLE
Fix tmpdir cleanups and add utils.h documentation

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -2,13 +2,78 @@
 
 #include <glib.h>
 
+/**
+ * Read file content into a GBytes.
+ *
+ * @param filename Filename to read from
+ * @param error return location for a GError, or NULL
+ *
+ * @return A newly allocated GBytes on success, NULL if an error occurred
+ */
 GBytes *read_file(const gchar *filename, GError **error);
+
+/**
+ * Read file content into a gchar.
+ *
+ * @param filename Filename to read from
+ * @param error return location for a GError, or NULL
+ *
+ * @return A newly allocated gchar on success, NULL if an error occurred
+ */
 gchar *read_file_str(const gchar *filename, GError **error);
+
+/**
+ * Write content of a GBytes to file.
+ *
+ * @param filename
+ * @param bytes
+ * @param error return location for a GError, or NULL
+ *
+ * @return TRUE on success, FALSE if an error occurred
+ */
 gboolean write_file(const gchar *filename, GBytes *bytes, GError **error);
 
+/**
+ * Copy a file.
+ *
+ * @param srcprefix Prefix path to append to filename given in srcfile
+ * @param srcfile filename or path of file to copy from
+ * @param dtsprefix Prefix path to append to filename given in dstfile
+ * @param dstfile filename or path of file to copy to
+ * @param error return location for a GError, or NULL
+ *
+ * @return TRUE on success, FALSE if an error occurred
+ */
 gboolean copy_file(const gchar *srcprefix, const gchar *srcfile,
 		const gchar *dstprefix, const gchar *dstfile, GError **error);
 
+/**
+ * Recursively delete directory contents.
+ *
+ * @param path path of directory to delete
+ * @param error return location for a GError, or NULL
+ *
+ * @return TRUE on success, FALSE if an error occurred
+ */
 gboolean rm_tree(const gchar *path, GError **error);
 
+/**
+ * Resolve path based on directory of `basefile` argument or current working dir.
+ *
+ * This is useful for parsing paths from config files where the path locations
+ * may depend on the config files location. In this case `path` would be the
+ * pathname set in the config file, and `basefile` would be the path to the
+ * config file itself.
+ *
+ * If given path itself is absolute, this will be returned.
+ * If `basefile` is given and absolute, its location (whith the pathname
+ * stripped) will be used as the prefix path for `path`.
+ * If `basefile` is not an absolute path, the current workding dir will be used
+ * as the prefix path for `path` instead.
+ *
+ * @param basefile Reference path to resolve `path` to
+ * @param path The path to resolve an absolute path for
+ *
+ * @return An absolute path name, determined as described above, NULL if undeterminable
+ */
 gchar *resolve_path(const gchar *basefile, gchar *path);

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include <install.h>
 #include <service.h>
 #include "rauc-installer-generated.h"
+#include "utils.h"
 
 GMainLoop *r_loop = NULL;
 int r_exit_status = 0;
@@ -290,7 +291,7 @@ static gboolean info_start(int argc, char **argv)
 out:
 	r_exit_status = res ? 0 : 1;
 	if (tmpdir)
-		g_rmdir(tmpdir);
+		rm_tree(tmpdir, NULL);
 
 	g_clear_pointer(&tmpdir, g_free);
 	g_clear_pointer(&bundledir, g_free);

--- a/test/common.c
+++ b/test/common.c
@@ -72,6 +72,32 @@ int test_mkdir_relative(const gchar *dirname, const gchar *filename, int mode) {
 	return res;
 }
 
+int test_rmdir(const gchar *dirname, const gchar *filename) {
+	gchar *path;
+	int res;
+
+	path = g_build_filename(dirname, filename, NULL);
+	g_assert_nonnull(path);
+
+	res = g_rmdir(path);
+
+	g_free(path);
+	return res;
+}
+
+gboolean test_rm_tree(const gchar *dirname, const gchar *filename) {
+	gchar *path;
+	gboolean res;
+
+	path = g_build_filename(dirname, filename, NULL);
+	g_assert_nonnull(path);
+
+	res = rm_tree(path, NULL);
+
+	g_free(path);
+	return res;
+}
+
 int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, gboolean custom_handler) {
 	gchar *path = g_build_filename(dirname, filename, NULL);
 	RaucManifest *rm = g_new0(RaucManifest, 1);

--- a/test/common.c
+++ b/test/common.c
@@ -199,12 +199,14 @@ out:
 
 gboolean test_umount(const gchar *dirname, const gchar *mountpoint) {
 	gchar *path;
+	gboolean res;
 	
 	path = g_build_filename(dirname, mountpoint, NULL);
+	g_assert_nonnull(path);
 
-	g_assert_true(r_umount(path, NULL));
+	res = r_umount(path, NULL);
 
-	return TRUE;
+	return res;
 }
 
 gboolean test_copy_file(const gchar *srcprefix, const gchar *srcfile, const gchar *dstprefix, const gchar *dstfile) {

--- a/test/common.h
+++ b/test/common.h
@@ -6,6 +6,8 @@
 int test_prepare_dummy_file(const gchar *dirname, const gchar *filename,
 			    gsize size, const gchar *source);
 int test_mkdir_relative(const gchar *dirname, const gchar *filename, int mode);
+int test_rmdir(const gchar *dirname, const gchar *filename);
+gboolean test_rm_tree(const gchar *dirname, const gchar *filename);
 int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, gboolean custom_handler);
 gboolean test_make_filesystem(const gchar *dirname, const gchar *filename);
 gboolean test_mount(const gchar *src, const gchar *dest);

--- a/test/install.c
+++ b/test/install.c
@@ -264,6 +264,8 @@ static void install_fixture_tear_down(InstallFixture *fixture,
 		gconstpointer user_data)
 {
 	test_umount(fixture->tmpdir, "slot");
+	test_umount(fixture->tmpdir, "mount");
+	test_rm_tree(fixture->tmpdir, "");
 }
 
 static void install_test_bootname(InstallFixture *fixture,


### PR DESCRIPTION
When running `rauc info` or executing test, a lot of artifacts were left in the /tmp directory.
This and some surrounding issues (such as lack of documentation of utils.h) are fixed by this PR.