### PR TITLE
fix some GError propagation prefix strings

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -31,7 +31,7 @@ static gboolean mksquashfs(const gchar *bundlename, const gchar *contentdir, GEr
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to start mksquashfs");
+				"Failed to start mksquashfs: ");
 		goto out;
 	}
 
@@ -40,7 +40,7 @@ static gboolean mksquashfs(const gchar *bundlename, const gchar *contentdir, GEr
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to run mksquashfs");
+				"Failed to run mksquashfs: ");
 		goto out;
 	}
 
@@ -76,7 +76,7 @@ static gboolean unsquashfs(const gchar *bundlename, const gchar *contentdir, con
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to start unsquashfs");
+				"Failed to start unsquashfs: ");
 		goto out;
 	}
 
@@ -85,7 +85,7 @@ static gboolean unsquashfs(const gchar *bundlename, const gchar *contentdir, con
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to run unsquashfs");
+				"Failed to run unsquashfs: ");
 		goto out;
 	}
 

--- a/src/install.c
+++ b/src/install.c
@@ -811,7 +811,7 @@ copy:
 
 		if (!res) {
 			g_propagate_prefixed_error(error, ierror,
-					"Failed copying image: ");
+					"Failed updating slot: ");
 			goto out;
 		}
 

--- a/src/mount.c
+++ b/src/mount.c
@@ -36,7 +36,7 @@ gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar*
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to start mount");
+				"failed to start mount: ");
 		goto out;
 	}
 
@@ -45,7 +45,7 @@ gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar*
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to run mount");
+				"failed to run mount: ");
 		goto out;
 	}
 


### PR DESCRIPTION
There should be a space between the prefix string and the original error
message to ease reading it.
