### PR TITLE
config_file: do not set bootname if config did not provide any

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -171,8 +171,6 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 			slot->type = value;
 
 			value = g_key_file_get_string(key_file, groups[i], "bootname", NULL);
-			if (!value)
-				value = g_strdup(slot->name);
 			slot->bootname = value;
 
 			slot->readonly = g_key_file_get_boolean(key_file, groups[i], "readonly", NULL);

--- a/src/install.c
+++ b/src/install.c
@@ -176,8 +176,8 @@ gboolean determine_slot_states(GError **error) {
 
 	for (GList *l = slotlist; l != NULL; l = l->next) {
 		RaucSlot *s = (RaucSlot*) g_hash_table_lookup(r_context()->config->slots, l->data);
-		if (!s->bootname && s->parent) {
-			g_warning("Warning: No bootname configured for %s", s->name);
+		if (!s->bootname) {
+			continue;
 		}
 
 		if (g_strcmp0(s->bootname, bootname) == 0) {
@@ -464,7 +464,7 @@ static gboolean launch_and_wait_handler(gchar* update_source, gchar *handler_nam
 		g_clear_pointer(&varname, g_free);
 
 		varname = g_strdup_printf("RAUC_SLOT_BOOTNAME_%i", slotcnt);
-		g_subprocess_launcher_setenv(handlelaunch, varname, slot->bootname, TRUE);
+		g_subprocess_launcher_setenv(handlelaunch, varname, slot->bootname ? slot->bootname : "", TRUE);
 		g_clear_pointer(&varname, g_free);
 
 		varname = g_strdup_printf("RAUC_SLOT_PARENT_%i", slotcnt);


### PR DESCRIPTION
To make the bootname checks for updating bootloader status working, no
default bootname must be set.
