### PR TITLE
main: disable gio vfs support

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -593,6 +593,9 @@ done:
 }
 
 int main(int argc, char **argv) {
+	/* disable remote VFS */
+	g_assert(g_setenv("GIO_USE_VFS", "local", TRUE));
+
 	cmdline_handler(argc, argv);
 
 	return r_exit_status;


### PR DESCRIPTION
GVFS needs the session bus for remote protocols and we don't use it.

Signed-off-by: Jan Luebbe <jlu@pengutronix.de>