### PR TITLE
install: disconnect all signal handlers that use args before destroying it

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -185,7 +185,7 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed signing bundle");
+				"failed signing bundle: ");
 		goto out;
 	}
 
@@ -195,7 +195,7 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to open bundle for appending");
+				"failed to open bundle for appending: ");
 		goto out;
 	}
 
@@ -205,7 +205,7 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to seek to end of bundle");
+				"failed to seek to end of bundle: ");
 		goto out;
 	}
 
@@ -215,7 +215,7 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to append signature to bundle");
+				"failed to append signature to bundle: ");
 		goto out;
 	}
 
@@ -226,7 +226,7 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to append signature size to bundle");
+				"failed to append signature size to bundle: ");
 		goto out;
 	}
 
@@ -263,7 +263,7 @@ gboolean check_bundle(const gchar *bundlename, gsize *size, gboolean verify, GEr
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to open bundle for reading");
+				"failed to open bundle for reading: ");
 		goto out;
 	}
 
@@ -274,7 +274,7 @@ gboolean check_bundle(const gchar *bundlename, gsize *size, gboolean verify, GEr
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to seek to end of bundle");
+				"failed to seek to end of bundle: ");
 		goto out;
 	}
 	offset = g_seekable_tell((GSeekable *)bundlestream);
@@ -285,7 +285,7 @@ gboolean check_bundle(const gchar *bundlename, gsize *size, gboolean verify, GEr
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to read signature size from bundle");
+				"failed to read signature size from bundle: ");
 		goto out;
 	}
 
@@ -300,7 +300,7 @@ gboolean check_bundle(const gchar *bundlename, gsize *size, gboolean verify, GEr
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to seek to start of bundle signature");
+				"failed to seek to start of bundle signature: ");
 		goto out;
 	}
 
@@ -310,7 +310,7 @@ gboolean check_bundle(const gchar *bundlename, gsize *size, gboolean verify, GEr
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to read signature from bundle");
+				"failed to read signature from bundle: ");
 		goto out;
 	}
 

--- a/src/install.c
+++ b/src/install.c
@@ -968,7 +968,7 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error) {
 	}
 
 	// TODO: mount info in context ?
-	g_message("Mounting bundle '%s' to '%s'\n", bundlefile, mountpoint);
+	g_message("Mounting bundle '%s' to '%s'", bundlefile, mountpoint);
 	install_args_update(args, "Checking and mounting bundle...");
 	res = mount_bundle(bundlefile, mountpoint, TRUE, &ierror);
 	if (!res) {

--- a/src/main.c
+++ b/src/main.c
@@ -36,15 +36,6 @@ static gboolean install_notify(gpointer data) {
 
 static gboolean install_cleanup(gpointer data)
 {
-	RaucInstallArgs *args = data;
-
-	g_mutex_lock(&args->status_mutex);
-	g_message("installing %s done: %d", args->name, args->status_result);
-	r_exit_status = args->status_result;
-	g_mutex_unlock(&args->status_mutex);
-
-	install_args_free(args);
-
 	g_main_loop_quit(r_loop);
 
 	return G_SOURCE_REMOVE;
@@ -98,9 +89,10 @@ static gboolean install_start(int argc, char **argv)
 
 	g_debug("install started");
 
+	r_exit_status = 1;
+
 	if (argc < 3) {
 		g_printerr("a bundle filename name must be provided\n");
-		r_exit_status = 1;
 		goto out;
 	}
 
@@ -117,6 +109,7 @@ static gboolean install_start(int argc, char **argv)
 	args->name = bundlelocation;
 	args->notify = install_notify;
 	args->cleanup = install_cleanup;
+	args->status_result = 2;
 
 	r_loop = g_main_loop_new(NULL, FALSE);
 	if (ENABLE_SERVICE) {
@@ -126,27 +119,37 @@ static gboolean install_start(int argc, char **argv)
 		if (g_signal_connect(installer, "g-properties-changed",
 				     G_CALLBACK(on_installer_changed), args) <= 0) {
 			g_error("failed to connect properties-changed signal");
-			goto out;
+			goto out_loop;
 		}
 		if (g_signal_connect(installer, "completed",
 				     G_CALLBACK(on_installer_completed), args) <= 0) {
 			g_error("failed to connect completed signal");
-			goto out;
+			goto out_loop;
 		}
 		g_print("trying to contact rauc service\n");
 		if (!r_installer_call_install_sync(installer, bundlelocation, NULL,
 						   &error)) {
 			g_warning("failed %s", error->message);
-			goto out;
+			goto out_loop;
 		}
 	} else {
 		install_run(args);
 	}
 
 	g_main_loop_run(r_loop);
-out:
+
+	g_message("installing %s done: %d", args->name, args->status_result);
+
+out_loop:
+	r_exit_status = args->status_result;
 	g_clear_pointer(&r_loop, g_main_loop_unref);
+
+	g_signal_handlers_disconnect_by_data(installer, args);
 	g_clear_pointer(&installer, g_object_unref);
+
+out:
+	install_args_free(args);
+
 	return TRUE;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -541,7 +541,7 @@ static void cmdline_handler(int argc, char **argv)
 
 	if (rcommand == NULL) {
 		/* INVALID COMMAND given */
-		g_message("Invalid command '%s' given\n", cmdarg);
+		g_message("Invalid command '%s' given", cmdarg);
 		r_exit_status = 1;
 		goto print_help;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -138,9 +138,22 @@ static gboolean install_start(int argc, char **argv)
 
 	g_main_loop_run(r_loop);
 
-	g_message("installing %s done: %d", args->name, args->status_result);
 
 out_loop:
+	switch (args->status_result) {
+		case 0:
+			g_print("installing `%s` succeeded\n", args->name);
+			break;
+		case 1:
+			g_printerr("installing `%s` failed\n", args->name);
+			break;
+		case 2:
+			g_printerr("D-Bus error while installing `%s`\n", args->name);
+			break;
+		default:
+			g_printerr("installing `%s` failed with unknown exit code: %d\n", args->name, args->status_result);
+			break;
+	}
 	r_exit_status = args->status_result;
 	g_clear_pointer(&r_loop, g_main_loop_unref);
 

--- a/src/mount.c
+++ b/src/mount.c
@@ -81,7 +81,7 @@ gboolean r_umount(const gchar *filename, GError **error) {
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to start umount");
+				"failed to start umount: ");
 		goto out;
 	}
 
@@ -90,7 +90,7 @@ gboolean r_umount(const gchar *filename, GError **error) {
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"failed to run umount");
+				"failed to run umount: ");
 		goto out;
 	}
 

--- a/src/service.c
+++ b/src/service.c
@@ -20,7 +20,7 @@ static gboolean service_install_notify(gpointer data) {
 	g_mutex_lock(&args->status_mutex);
 	while (!g_queue_is_empty(&args->status_messages)) {
 		gchar *msg = g_queue_pop_head(&args->status_messages);
-		g_message("installing %s: %s\n", args->name, msg);
+		g_message("installing %s: %s", args->name, msg);
 		g_dbus_interface_skeleton_flush(G_DBUS_INTERFACE_SKELETON(r_installer));
 	}
 	g_mutex_unlock(&args->status_mutex);
@@ -92,7 +92,7 @@ static gboolean auto_install(const gchar *source) {
 	if (!g_file_test(r_context()->config->autoinstall_path, G_FILE_TEST_EXISTS))
 		return FALSE;
 
-	g_message("input bundle: %s\n", source);
+	g_message("input bundle: %s", source);
 
 	res = !r_context_get_busy();
 	if (!res)
@@ -163,7 +163,7 @@ static void r_on_name_acquired(GDBusConnection *connection,
 static void r_on_name_lost(GDBusConnection *connection,
 			   const gchar     *name,
 			   gpointer         user_data) {
-	g_message("name lost, stopping service\n");
+	g_message("name lost, stopping service");
 	if (service_loop) {
 		g_main_loop_quit(service_loop);
 	}
@@ -173,7 +173,7 @@ static void r_on_name_lost(GDBusConnection *connection,
 
 static gboolean r_on_signal(gpointer user_data)
 {
-	g_message("stopping service\n");
+	g_message("stopping service");
 	if (service_loop) {
 		g_main_loop_quit(service_loop);
 	}

--- a/src/service.c
+++ b/src/service.c
@@ -33,7 +33,11 @@ static gboolean service_install_cleanup(gpointer data)
 	RaucInstallArgs *args = data;
 
 	g_mutex_lock(&args->status_mutex);
-	g_message("installing %s done: %d\n", args->name, args->status_result);
+	if (args->status_result == 0) {
+		g_message("installing `%s` succeeded", args->name);
+	} else {
+		g_message("installing `%s` failed: %d", args->name, args->status_result);
+	}
 	r_installer_emit_completed(r_installer, args->status_result);
 	r_installer_set_operation(r_installer, "idle");
 	g_mutex_unlock(&args->status_mutex);

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -493,7 +493,7 @@ img_to_slot_handler get_update_handler(RaucImage *mfimage, RaucSlot *dest_slot, 
 		//g_message("Checking for pattern: %s", (gchar*)l->data);
 		if (g_pattern_match_simple(updatepair->src, src) &&
 		    g_pattern_match_simple(updatepair->dest, dest)) {
-			g_message("Image detected as type: %s\n", updatepair->src);
+			g_message("Image detected as type: %s", updatepair->src);
 			handler = updatepair->handler;
 			break;
 		}


### PR DESCRIPTION
This will prevent the client handlers from accessing args when might
have already been cleared.

This fixes a segfault that occured while rauc terminated with an error
code.
And, this should also fix the following error:

| Unexpected error from C library during 'pthread_mutex_lock': Invalid
| argument.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>