### PR TITLE
rauc.t: fix rauc test command chaining

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -365,7 +365,7 @@ static gboolean status_start(int argc, char **argv)
 	}
 
 	if (argc < 3) {
-		r_exit_status = 1;
+		r_exit_status = 0;
 		goto out;
 	}
 

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -17,12 +17,12 @@ test_expect_success "rauc invalid cmd" "
 "
 
 test_expect_success "rauc missing arg" "
-  test_must_fail rauc install
-  test_must_fail rauc info
-  test_must_fail rauc bundle
-  test_must_fail rauc checksum
-  test_must_fail rauc resign
-  test_must_fail rauc install
+  test_must_fail rauc install &&
+  test_must_fail rauc info &&
+  test_must_fail rauc bundle &&
+  test_must_fail rauc checksum &&
+  test_must_fail rauc resign &&
+  test_must_fail rauc install &&
   test_must_fail rauc info
 "
 
@@ -64,7 +64,7 @@ test_expect_success "rauc bundle" "
   rauc \
     --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \
     --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
-    bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb
+    bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
   rauc -c $SHARNESS_TEST_DIRECTORY/test.conf info out.raucb
 "
 
@@ -72,8 +72,8 @@ test_expect_success "rauc bundle" "
 test_expect_success "rauc status" "
   cp $SHARNESS_TEST_DIRECTORY/test.conf $SHARNESS_TEST_DIRECTORY/test-temp.conf
   sed -i 's!bootname=system0!bootname=$(cat /proc/cmdline | sed 's/.*root=\([^ ]*\).*/\1/')!g' $SHARNESS_TEST_DIRECTORY/test-temp.conf
-  rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status
-  rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status mark-good
+  rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status &&
+  rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status mark-good &&
   rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status mark-bad
 "
 


### PR DESCRIPTION
Commands must be chained with `&&` in order to let the tests fail
correctly in case of an error. Otherwise the error code of the
previously executed command would be overwritten by the next.

This also fixes a bug in `rauc status` that was hidden due to the ignored tests.