### PR TITLE
main: in case of local bundle, check for extension and existence

### DIFF
--- a/test/rauc.t
+++ b/test/rauc.t
@@ -77,4 +77,10 @@ test_expect_success "rauc status" "
   rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status mark-bad
 "
 
+test_expect_success "rauc install invalid local paths" "
+  test_must_fail rauc install foo &&
+  test_must_fail rauc install foo.raucb &&
+  test_must_fail rauc install /path/to/foo.raucb
+"
+
 test_done


### PR DESCRIPTION
The installer should fail earlier and more verbose when trying to
install a bundle with an invalid name or non-existing path.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>