### PR TITLE
signature: obtain verbose error string for CMS_verify() failures

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -207,11 +207,15 @@ gboolean cms_verify(GBytes *content, GBytes *sig, GError **error) {
 	}
 
 	if (!CMS_verify(cms, other, store, incontent, NULL, CMS_DETACHED)) {
+		unsigned long err;
+		const gchar *data;
+		int flags;
+		err = ERR_get_error_line_data(NULL, NULL, &data, &flags);
 		g_set_error(
 				error,
 				R_SIGNATURE_ERROR,
 				R_SIGNATURE_ERROR_INVALID,
-				"invalid signature");
+				"signature verification failed: %s", (flags & ERR_TXT_STRING) ? data : ERR_error_string(err, NULL));
 		goto out;
 	}
 


### PR DESCRIPTION
The genreic error message "signature error" is too unspecific to debug
issues with certificates. The Openssl library routines provide routines
to for getting more precise error codes and messages which are used
here.

A side-effect of this is that the openssl library does not print error
messages in its own format directly to screen, but only through the
normal rauc error reporting mechanism.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>