### PR TITLE
give access to version from manifest in rauc info and via D-BUS

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -305,6 +305,7 @@ static gboolean info_start(int argc, char **argv)
 	}
 
 	g_print("Compatible String:\t'%s'\n", manifest->update_compatible);
+	g_print("Update version:   \t'%s'\n", manifest->update_version);
 
 	cnt = g_list_length(manifest->images);
 	g_print("%d Image%s%s\n", cnt, cnt == 1 ? "" : "s", cnt > 0 ? ":" : "");

--- a/src/rauc-installer.xml
+++ b/src/rauc-installer.xml
@@ -4,6 +4,18 @@
       <arg name="source" type="s"/>
     </method>
 
+   <!--
+    Info: D-Bus variant of rauc info <bundle>
+    @bundle: full path to the queried bundle.
+    @compatile: the compatible string from the bundle
+    @version: the version string from the bundle
+   -->
+   <method name="Info">
+      <arg name="bundle" type="s" direction="in" />
+      <arg name="compatible" type="s" direction="out" />
+      <arg name="version" type="s" direction="out" />
+    </method>
+
     <property name="Operation" type="s" access="read"/>
     <property name="LastError" type="s" access="read"/>
     <property name="Progress" type="(isi)" access="read"/>


### PR DESCRIPTION
rauc info is extended to show the version as well as compatible.
A new D-Bus method "Info" introduced that returns compatible+version.
The test harness is extended to test that the new D-Bus method works.

As this is the first time using pull requests on github I may have failed something.
And I would then be happy to submit as patches.

/Sam