### PR TITLE
rauc status: allow to choose output style

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -481,6 +481,30 @@ out:
 	return TRUE;
 }
 
+/* returns string representation of slot state */
+static gchar* slotstate_to_str(SlotState slotstate)
+{
+	gchar *state = NULL;
+
+	switch (slotstate) {
+	case ST_ACTIVE:
+		state = g_strdup("active");
+		break;
+	case ST_INACTIVE:
+		state = g_strdup("inactive");
+		break;
+	case ST_BOOTED:
+		state = g_strdup("booted");
+		break;
+	case ST_UNKNOWN:
+	default:
+		g_error("invalid slot status %d", slotstate);
+		break;
+	}
+
+	return state;
+}
+
 static gboolean status_start(int argc, char **argv)
 {
 	GHashTableIter iter;
@@ -506,27 +530,13 @@ static gboolean status_start(int argc, char **argv)
 	while (g_hash_table_iter_next(&iter, &key, &value)) {
 		gchar *name = key;
 		RaucSlot *slot = value;
-		const gchar *state = NULL;
-		switch (slot->state) {
-		case ST_ACTIVE:
-			state = "active";
-			break;
-		case ST_INACTIVE:
-			state = "inactive";
-			break;
-		case ST_BOOTED:
-			state = "booted";
+
+		if (slot->state == ST_BOOTED) {
 			booted = slot;
-			break;
-		case ST_UNKNOWN:
-		default:
-			g_error("invalid slot status");
-			r_exit_status = 1;
-			break;
 		}
 		g_print("  %s: class=%s, device=%s, type=%s, bootname=%s\n",
 			name, slot->sclass, slot->device, slot->type, slot->bootname);
-		g_print("      state=%s, description=%s", state, slot->description);
+		g_print("      state=%s, description=%s", slotstate_to_str(slot->state), slot->description);
 		if (slot->parent)
 			g_print(", parent=%s", slot->parent->name);
 		else

--- a/src/main.c
+++ b/src/main.c
@@ -561,7 +561,13 @@ static gboolean status_start(int argc, char **argv)
 		goto out;
 	}
 
-	text = r_status_formatter_readable();
+	if (!output_format || g_strcmp0(output_format, "readable") == 0) {
+		text = r_status_formatter_readable();
+	} else {
+		g_printerr("Unknown output format: '%s'\n", output_format);
+		r_exit_status = 1;
+		goto out;
+	}
 
 	g_print("%s\n", text);
 
@@ -640,6 +646,11 @@ GOptionEntry entries_info[] = {
 	{0}
 };
 
+GOptionEntry entries_status[] = {
+	{"output-format", '\0', 0, G_OPTION_ARG_STRING, &output_format, "output format", "FORMAT"},
+	{0}
+};
+
 static void cmdline_handler(int argc, char **argv)
 {
 	gboolean help = FALSE, version = FALSE;
@@ -658,6 +669,7 @@ static void cmdline_handler(int argc, char **argv)
 		{0}
 	};
 	GOptionGroup *info_group = g_option_group_new("info", "Info options:", "help dummy", NULL, NULL);
+	GOptionGroup *status_group = g_option_group_new("status", "Status options:", "help dummy", NULL, NULL);
 
 	GError *error = NULL;
 	gchar *text;
@@ -668,7 +680,7 @@ static void cmdline_handler(int argc, char **argv)
 		{BUNDLE, "bundle", "bundle <FILE>", bundle_start, NULL, FALSE},
 		{CHECKSUM, "checksum", "checksum <DIRECTORY>", checksum_start, NULL, FALSE},
 		{INFO, "info", "info <FILE>", info_start, info_group, FALSE},
-		{STATUS, "status", "status", status_start, NULL, TRUE},
+		{STATUS, "status", "status", status_start, status_group, TRUE},
 #if ENABLE_SERVICE == 1
 		{SERVICE, "service", "service", service_start, NULL, TRUE},
 #endif
@@ -678,6 +690,7 @@ static void cmdline_handler(int argc, char **argv)
 	RaucCommand *rcommand = NULL;
 
 	g_option_group_add_entries(info_group, entries_info);
+	g_option_group_add_entries(status_group, entries_status);
 
 	context = g_option_context_new("<COMMAND>");
 	g_option_context_set_help_enabled(context, FALSE);

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -107,6 +107,14 @@ test_expect_success "rauc status shell" "
   rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status --output-format=shell
 "
 
+test_expect_success JSON "rauc status json" "
+  rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status --output-format=json
+"
+
+test_expect_success JSON "rauc status json-pretty" "
+  rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status --output-format=json-pretty
+"
+
 test_expect_success "rauc status invalid" "
   test_must_fail rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status --output-format=invalid
 "

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -103,6 +103,10 @@ test_expect_success "rauc status readable" "
   rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status --output-format=readable
 "
 
+test_expect_success "rauc status shell" "
+  rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status --output-format=shell
+"
+
 test_expect_success "rauc status invalid" "
   test_must_fail rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status --output-format=invalid
 "

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -92,12 +92,26 @@ test_expect_success "rauc bundle" "
   rauc -c $SHARNESS_TEST_DIRECTORY/test.conf info out.raucb
 "
 
+cp $SHARNESS_TEST_DIRECTORY/test.conf $SHARNESS_TEST_DIRECTORY/test-temp.conf
+sed -i "s!bootname=system0!bootname=$(cat /proc/cmdline | sed 's/.*root=\([^ ]*\).*/\1/')!g" $SHARNESS_TEST_DIRECTORY/test-temp.conf
 
 test_expect_success "rauc status" "
-  cp $SHARNESS_TEST_DIRECTORY/test.conf $SHARNESS_TEST_DIRECTORY/test-temp.conf
-  sed -i 's!bootname=system0!bootname=$(cat /proc/cmdline | sed 's/.*root=\([^ ]*\).*/\1/')!g' $SHARNESS_TEST_DIRECTORY/test-temp.conf
-  rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status &&
-  rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status mark-good &&
+  rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status
+"
+
+test_expect_success "rauc status readable" "
+  rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status --output-format=readable
+"
+
+test_expect_success "rauc status invalid" "
+  test_must_fail rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status --output-format=invalid
+"
+
+test_expect_success "rauc status mark-good" "
+  rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status mark-good
+"
+
+test_expect_success "rauc status mark-bad" "
   rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status mark-bad
 "
 


### PR DESCRIPTION
This introduces a `output-format` optional parameter for `rauc status` which allows to select the desired printout style.
This will be helpful to either get human readable or parsable output.

Currently supported formats are:
* human readable
* shell-parsable
* json
* json-pretty (with line breaks and indention)

Note that having 'json-glib' on the system is required for building with json support. The configure switch `--disable-json` allows building rauc without json support.

This obsoletes PR #26 