### PR TITLE
allow to disable network support for not using libcurl

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,7 +42,6 @@ librauc_la_SOURCES = \
 	src/install.c \
 	src/manifest.c \
 	src/mount.c \
-	src/network.c \
 	src/service.c \
 	src/signature.c \
 	src/utils.c \
@@ -55,12 +54,14 @@ librauc_la_SOURCES = \
 	include/install.h \
 	include/manifest.h \
 	include/mount.h \
-	include/network.h \
 	include/service.h \
 	include/signature.h \
 	include/update_handler.h \
 	include/utils.h
 
+if WANT_NETWORK
+librauc_la_SOURCES += src/network.c include/network.h
+endif
 nodist_librauc_la_SOURCES = \
 	$(gdbus_installer_generated)
 librauc_la_CFLAGS = $(AM_CFLAGS) $(CODE_COVERAGE_CFLAGS)
@@ -106,10 +107,14 @@ check_PROGRAMS = \
 	test/signature.test \
 	test/update_handler.test \
 	test/install.test \
-	test/network.test \
 	test/service.test \
 	test/bundle.test \
 	test/progress.test
+
+if WANT_NETWORK
+check_PROGRAMS += test/network.test
+endif
+
 check_LTLIBRARIES = librauctest.la
 
 EXTRA_DIST += tap-t \

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,18 @@ AS_IF([test "x$enable_service" != "xno"], [
 
 # Checks for libraries.
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.40 gio-2.0 gio-unix-2.0])
-PKG_CHECK_MODULES([CURL], [libcurl])
+
+AC_ARG_ENABLE([network],
+       AS_HELP_STRING([--disable-network], [Disable network update mode])
+)
+AM_CONDITIONAL([WANT_NETWORK], [test x$enable_network != xno])
+AS_IF([test "x$enable_network" != "xno"], [
+       AC_DEFINE([ENABLE_NETWORK], [1], [Define to 1 to enable building with JSON support])
+       PKG_CHECK_MODULES([CURL], [libcurl])
+], [
+       AC_DEFINE([ENABLE_NETWORK], [0])
+])
+
 
 AX_CHECK_OPENSSL([],[AC_MSG_ERROR([OpenSSL not found])])
 

--- a/include/install.h
+++ b/include/install.h
@@ -22,7 +22,7 @@ GList* get_slot_class_members(const gchar* slotclass);
 GHashTable* determine_target_install_group(RaucManifest *manifest);
 
 gboolean do_install_bundle(RaucInstallArgs *args, GError **error);
-gboolean do_install_network(const gchar *url);
+gboolean do_install_network(const gchar *url, GError **error);
 
 
 RaucInstallArgs *install_args_new(void);

--- a/include/network.h
+++ b/include/network.h
@@ -3,8 +3,13 @@
 #include <glib.h>
 
 #include <checksum.h>
+#include <config.h>
 
+#if ENABLE_NETWORK
 void network_init(void);
+#else
+static inline void network_init(void) { return; }
+#endif
 
 gboolean download_file(const gchar *target, const gchar *url, gsize limit);
 gboolean download_file_checksum(const gchar *target, const gchar *url,

--- a/src/install.c
+++ b/src/install.c
@@ -23,6 +23,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <config.h>
 
 #define R_SLOT_ERROR r_slot_error_quark ()
 
@@ -779,6 +780,7 @@ early_out:
 	return res;
 }
 
+#if ENABLE_NETWORK
 static gboolean reuse_existing_file_checksum(const RaucChecksum *checksum, const gchar *filename) {
 	GError *error = NULL;
 	gboolean res = FALSE;
@@ -945,6 +947,7 @@ slot_out:
 out:
 	return res;
 }
+#endif
 
 static void print_slot_hash_table(GHashTable *hash_table) {
 	GHashTableIter iter;
@@ -1063,6 +1066,7 @@ out:
 }
 
 gboolean do_install_network(const gchar *url, GError **error) {
+#if ENABLE_NETWORK
 	gboolean res = FALSE;
 	GError *ierror = NULL;
 	gchar *base_url = NULL, *signature_url = NULL;
@@ -1159,6 +1163,14 @@ out:
 	g_clear_pointer(&signature_data, g_bytes_unref);
 
 	return res;
+#else
+	g_set_error_literal(
+			error,
+			R_HANDLER_ERROR,
+			255,
+			"Compiled without network support");
+	return FALSE;
+#endif
 }
 
 static gboolean install_done(gpointer data) {

--- a/src/main.c
+++ b/src/main.c
@@ -173,7 +173,8 @@ out_loop:
 	r_exit_status = args->status_result;
 	g_clear_pointer(&r_loop, g_main_loop_unref);
 
-	g_signal_handlers_disconnect_by_data(installer, args);
+	if (installer)
+		g_signal_handlers_disconnect_by_data(installer, args);
 	g_clear_pointer(&installer, g_object_unref);
 	install_args_free(args);
 

--- a/test/install.c
+++ b/test/install.c
@@ -516,17 +516,17 @@ static void install_test_network(InstallFixture *fixture,
 
 	manifesturl = g_strconcat("file://", fixture->tmpdir,
 				  "/content/manifest-1.raucm", NULL);
-	g_assert_true(do_install_network(manifesturl));
+	g_assert_true(do_install_network(manifesturl, NULL));
 	g_free(manifesturl);
 
 	manifesturl = g_strconcat("file://", fixture->tmpdir,
 				  "/content/manifest-2.raucm", NULL);
-	g_assert_true(do_install_network(manifesturl));
+	g_assert_true(do_install_network(manifesturl, NULL));
 	g_free(manifesturl);
 
 	manifesturl = g_strconcat("file://", fixture->tmpdir,
 				  "/content/manifest-3.raucm", NULL);
-	g_assert_true(do_install_network(manifesturl));
+	g_assert_true(do_install_network(manifesturl, NULL));
 	g_free(manifesturl);
 }
 
@@ -579,7 +579,7 @@ static void install_test_network_thread(InstallFixture *fixture,
 
 	manifesturl = g_strconcat("file://", fixture->tmpdir,
 				  "/content/manifest-1.raucm", NULL);
-	g_assert_true(do_install_network(manifesturl));
+	g_assert_true(do_install_network(manifesturl, NULL));
 	args->name = g_strdup(manifesturl);
 	args->notify = install_notify;
 	args->cleanup = install_cleanup;

--- a/test/install.c
+++ b/test/install.c
@@ -6,6 +6,7 @@
 
 #include <bundle.h>
 #include <context.h>
+#include <config.h>
 #include <install.h>
 #include <manifest.h>
 #include <mount.h>
@@ -299,6 +300,10 @@ static void install_fixture_set_up_network(InstallFixture *fixture,
 	gchar *contentdir;
 	gchar *manifestpath;
 
+#if !ENABLE_NETWORK
+	return;
+#endif
+
 	/* needs to run as root */
 	if (!test_running_as_root())
 		return;
@@ -504,6 +509,11 @@ static void install_test_network(InstallFixture *fixture,
 {
 	gchar *manifesturl, *mountdir;
 
+#if !ENABLE_NETWORK
+	g_test_skip("Compiled without network support");
+	return;
+#endif
+
 	/* needs to run as root */
 	if (!test_running_as_root())
 		return;
@@ -566,6 +576,11 @@ static void install_test_network_thread(InstallFixture *fixture,
 {
 	RaucInstallArgs *args = install_args_new();
 	gchar *manifesturl, *mountdir;
+
+#if !ENABLE_NETWORK
+	g_test_skip("Compiled without network support");
+	return;
+#endif
 
 	/* needs to run as root */
 	if (!test_running_as_root())


### PR DESCRIPTION
Unconditionally depending on libcurl adds a lot of dependencies that are
not required for most of raucs operation modes.

Thus this patch introduces a `--disable-network` configure switch.
