### PR TITLE
Extend tests

### DIFF
--- a/include/bundle.h
+++ b/include/bundle.h
@@ -2,6 +2,13 @@
 
 #include <glib.h>
 
+#define R_BUNDLE_ERROR r_bundle_error_quark ()
+GQuark r_bundle_error_quark(void);
+
+typedef enum {
+	R_BUNDLE_ERROR_SIGNATURE
+} RBundleError;
+
 gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError **error);
 gboolean check_bundle(const gchar *bundlename, gsize *size, gboolean verify, GError **error);
 gboolean extract_bundle(const gchar *bundlename, const gchar *outputdir, gboolean verify, GError **error);

--- a/src/install.c
+++ b/src/install.c
@@ -1021,12 +1021,12 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error) {
 	if (r_context()->config->preinstall_handler) {
 		g_print("Starting pre install handler: %s\n", r_context()->config->preinstall_handler);
 		res = launch_and_wait_handler(mountpoint, r_context()->config->preinstall_handler, manifest, target_group, &ierror);
+		if (!res) {
+			g_propagate_prefixed_error(error, ierror, "Handler error: ");
+			goto out;
+		}
 	}
 
-	if (!res) {
-		g_propagate_prefixed_error(error, ierror, "Handler error: ");
-		goto out;
-	}
 
 	if (manifest->handler_name) {
 		g_print("Using custom handler: %s\n", manifest->handler_name);
@@ -1044,12 +1044,12 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error) {
 	if (r_context()->config->postinstall_handler) {
 		g_print("Starting post install handler: %s\n", r_context()->config->postinstall_handler);
 		res = launch_and_wait_handler(mountpoint, r_context()->config->postinstall_handler, manifest, target_group, &ierror);
+		if (!res) {
+			g_propagate_prefixed_error(error, ierror, "Handler error: ");
+			goto umount;
+		}
 	}
 
-	if (!res) {
-		g_propagate_prefixed_error(error, ierror, "Handler error: ");
-		goto umount;
-	}
 
 	res = TRUE;
 
@@ -1127,12 +1127,12 @@ gboolean do_install_network(const gchar *url, GError **error) {
 	if (r_context()->config->preinstall_handler) {
 		g_print("Starting pre install handler: %s\n", r_context()->config->preinstall_handler);
 		res = launch_and_wait_handler(base_url, r_context()->config->preinstall_handler, manifest, target_group, &ierror);
+		if (!res) {
+			g_propagate_prefixed_error(error, ierror, "Handler error: ");
+			goto out;
+		}
 	}
 
-	if (!res) {
-		g_propagate_prefixed_error(error, ierror, "Handler error: ");
-		goto out;
-	}
 
 	g_print("Using network handler for %s\n", base_url);
 	res = launch_and_wait_network_handler(base_url, manifest, target_group);
@@ -1145,12 +1145,12 @@ gboolean do_install_network(const gchar *url, GError **error) {
 	if (r_context()->config->postinstall_handler) {
 		g_print("Starting post install handler: %s\n", r_context()->config->postinstall_handler);
 		res = launch_and_wait_handler(base_url, r_context()->config->postinstall_handler, manifest, target_group, &ierror);
+		if (!res) {
+			g_propagate_prefixed_error(error, ierror, "Handler error: ");
+			goto out;
+		}
 	}
 
-	if (!res) {
-		g_propagate_prefixed_error(error, ierror, "Handler error: ");
-		goto out;
-	}
 
 	res = TRUE;
 

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -2,6 +2,7 @@
 #include <locale.h>
 #include <glib.h>
 #include <glib/gstdio.h>
+#include <gio/gio.h>
 
 #include <bundle.h>
 #include <context.h>
@@ -34,6 +35,42 @@ static void bundle_fixture_tear_down(BundleFixture *fixture,
 {
 	g_assert_true(rm_tree(fixture->tmpdir, NULL));
 	g_free(fixture->tmpdir);
+}
+
+static void test_check_empty_bundle(BundleFixture *fixture,
+		gconstpointer user_data)
+{
+	gchar *bundlename;
+	gsize size;
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+
+	bundlename = write_random_file(fixture->tmpdir, "bundle.raucb", 0, 1234);
+	g_assert_nonnull(bundlename);
+
+	res = check_bundle(bundlename, &size, TRUE, &ierror);
+	g_assert_error(ierror, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT);
+	g_assert_false(res);
+
+	g_free(bundlename);
+}
+
+static void test_check_invalid_bundle(BundleFixture *fixture,
+		gconstpointer user_data)
+{
+	gchar *bundlename;
+	gsize size;
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+
+	bundlename = write_random_file(fixture->tmpdir, "bundle.raucb", 1024, 1234);
+	g_assert_nonnull(bundlename);
+
+	res = check_bundle(bundlename, &size, FALSE, &ierror);
+	g_assert_error(ierror, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE);
+	g_assert_false(res);
+
+	g_free(bundlename);
 }
 
 static void bundle_test1(BundleFixture *fixture,
@@ -163,6 +200,14 @@ int main(int argc, char *argv[])
 	r_context();
 
 	g_test_init(&argc, &argv, NULL);
+
+	g_test_add("/bundle/check/empty", BundleFixture, NULL,
+		   bundle_fixture_set_up, test_check_empty_bundle,
+		   bundle_fixture_tear_down);
+
+	g_test_add("/bundle/check/invalid", BundleFixture, NULL,
+		   bundle_fixture_set_up, test_check_invalid_bundle,
+		   bundle_fixture_tear_down);
 
 	g_test_add("/bundle/test1", BundleFixture, NULL,
 		   bundle_fixture_set_up, bundle_test1,

--- a/test/common.c
+++ b/test/common.c
@@ -14,6 +14,33 @@ typedef struct {
 	gchar *tmpdir;
 } InstallFixture;
 
+gchar* random_bytes(gsize size, guint32 seed) {
+	gchar *str = g_new0(gchar, size + 1);
+	GRand *rand = g_rand_new_with_seed(seed);
+	for (gsize i = 0; i < size; i++) {
+		str[i] = (gchar) g_rand_int(rand) & 0xFF;
+	}
+	return str;
+}
+
+gchar* write_random_file(const gchar *tmpdir, const gchar *filename,
+			    gsize size, const guint32 seed) {
+	gchar *pathname;
+	gchar *content;
+
+	pathname = g_build_filename(tmpdir, filename, NULL);
+	g_assert_nonnull(pathname);
+
+	content = random_bytes(size, seed);
+
+	if (!g_file_set_contents(pathname, content, size, NULL)) {
+		return NULL;
+	}
+
+	g_free(content);
+	return pathname;
+}
+
 /* Helper that writes string to new file in tmpdir/filename, returns entire
  * pathname if successful. */
 gchar* write_tmp_file(

--- a/test/common.h
+++ b/test/common.h
@@ -3,6 +3,9 @@
 #include <config.h>
 #include <glib.h>
 
+gchar* random_bytes(gsize size, guint32 seed);
+gchar* write_random_file(const gchar *tmpdir, const gchar *filename,
+			    gsize size, const guint32 seed);
 gchar* write_tmp_file(const gchar* tmpdir, const gchar* filename, const gchar* content, GError **error);
 int test_prepare_dummy_file(const gchar *dirname, const gchar *filename,
 			    gsize size, const gchar *source);

--- a/test/install.c
+++ b/test/install.c
@@ -122,8 +122,9 @@ static void install_fixture_set_up(InstallFixture *fixture,
 	g_free(slotpath);
 }
 
-static void install_fixture_set_up_bundle(InstallFixture *fixture,
-		gconstpointer user_data) {
+static void set_up_bundle(InstallFixture *fixture,
+		gconstpointer user_data,
+		gboolean handler) {
 	gchar *contentdir;
 	gchar *bundlepath;
 	gchar *mountdir;
@@ -160,6 +161,11 @@ static void install_fixture_set_up_bundle(InstallFixture *fixture,
 	g_assert_true(r_umount(mountdir, NULL));
 	g_assert(test_rmdir(fixture->tmpdir, "mnt") == 0);
 
+	/* Copy custom handler */
+	if (handler) {
+		g_assert_true(test_copy_file("test/install-content/custom_handler.sh", NULL,
+					fixture->tmpdir, "content/custom_handler.sh"));
+	}
 
 	/* Update checksums in manifest */
 	g_assert_true(update_manifest(contentdir, FALSE, NULL));
@@ -173,58 +179,14 @@ static void install_fixture_set_up_bundle(InstallFixture *fixture,
 	g_free(testfilepath);
 }
 
+static void install_fixture_set_up_bundle(InstallFixture *fixture,
+		gconstpointer user_data) {
+	set_up_bundle(fixture, user_data, FALSE);
+}
+
 static void install_fixture_set_up_bundle_custom_handler(InstallFixture *fixture,
 		gconstpointer user_data) {
-	gchar *contentdir;
-	gchar *bundlepath;
-	gchar *mountdir;
-	gchar *testfilepath;
-
-	/* needs to run as root */
-	if (!test_running_as_root())
-		return;
-
-	install_fixture_set_up(fixture, user_data);
-
-	contentdir = g_build_filename(fixture->tmpdir, "content", NULL);
-	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
-	mountdir = g_build_filename(fixture->tmpdir, "mnt", NULL);
-	testfilepath = g_build_filename(mountdir, "verify.txt", NULL);
-
-	/* Setup bundle content */
-	g_assert(test_prepare_dummy_file(fixture->tmpdir, "content/rootfs.ext4",
-					 64*1024*1024, "/dev/zero") == 0);
-	g_assert(test_prepare_dummy_file(fixture->tmpdir, "content/appfs.ext4",
-					 32*1024*1024, "/dev/zero") == 0);
-	g_assert_true(test_make_filesystem(fixture->tmpdir, "content/rootfs.ext4"));
-	g_assert_true(test_make_filesystem(fixture->tmpdir, "content/appfs.ext4"));
-	g_assert(test_prepare_manifest_file(fixture->tmpdir, "content/manifest.raucm", TRUE) == 0);
-
-	/* Copy custom handler */
-	g_assert_true(test_copy_file("test/install-content/custom_handler.sh", NULL,
-				fixture->tmpdir, "content/custom_handler.sh"));
-
-	/* Make images user-writable */
-	test_make_slot_user_writable(fixture->tmpdir, "content/rootfs.ext4");
-	test_make_slot_user_writable(fixture->tmpdir, "content/appfs.ext4");
-
-	/* Write test file to slot */
-	g_assert(test_mkdir_relative(fixture->tmpdir, "mnt", 0777) == 0);
-	g_assert_true(test_mount(g_build_filename(fixture->tmpdir, "content/rootfs.ext4", NULL), mountdir));
-	g_assert_true(g_file_set_contents(testfilepath, "0xdeadbeaf", -1, NULL));
-	g_assert_true(r_umount(mountdir, NULL));
-	g_assert(test_rmdir(fixture->tmpdir, "mnt") == 0);
-
-	/* Update checksums in manifest */
-	g_assert_true(update_manifest(contentdir, FALSE, NULL));
-
-	/* Create bundle */
-	g_assert_true(create_bundle(bundlepath, contentdir, NULL));
-
-	g_free(bundlepath);
-	g_free(contentdir);
-	g_free(mountdir);
-	g_free(testfilepath);
+	set_up_bundle(fixture, user_data, TRUE);
 }
 
 static void install_fixture_set_up_system_conf(InstallFixture *fixture,

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -38,6 +38,14 @@ static void manifest_check_common(RaucManifest *rm) {
 	}
 }
 
+/* Test manifest/load:
+ *
+ * Tests loading manifest from file: *
+ * Test cases:
+ * - load a valid manifest file
+ * - load a non-exisiting manifest file
+ * - load a broken manifest file
+ */
 static void test_load_manifest(void)
 {
 	RaucManifest *rm = NULL;
@@ -69,6 +77,13 @@ static void test_load_manifest(void)
 
 }
 
+/* Test manifest/save_load:
+ *
+ * Tests saving manifest structure to file and load again.
+ *
+ * Test cases:
+ * - save a valid manifest to file and load
+ */
 static void test_save_load_manifest(void)
 {
 	RaucManifest *rm = g_new0(RaucManifest, 1);
@@ -146,6 +161,13 @@ static void test_save_load_manifest(void)
 }
 
 
+/* Test manifest/load_mem:
+ *
+ * Tests loading manifest from memory.
+ *
+ * Test cases:
+ * - load a valid manifest from memory
+ */
 static void test_load_manifest_mem(void)
 {
 	GBytes *data = NULL;


### PR DESCRIPTION
This is some pre-work for further test setups that fixes some issues, reduces a little bit of code duplication and extend tests by some newly added one and some more tested details.

* Adds test for some error paths in bundle checks
* shares common code in bundle test routines
* Tests if updates actually write content
* Add a little bit of test description