### PR TITLE
Introduce Hooks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -127,6 +127,7 @@ AC_CONFIG_LINKS([test/services/de.pengutronix.rauc.service.in:test/services/de.p
 AC_CONFIG_LINKS([test/sharness.sh:test/sharness.sh])
 AC_CONFIG_LINKS([test/install-content/appfs.img:test/install-content/appfs.img])
 AC_CONFIG_LINKS([test/install-content/rootfs.img:test/install-content/rootfs.img])
+AC_CONFIG_LINKS([test/install-content/hook.sh:test/install-content/hook.sh])
 AC_CONFIG_LINKS([test/install-content/custom_handler.sh:test/install-content/custom_handler.sh])
 AC_CONFIG_LINKS([test/install-content/manifest.raucm:test/install-content/manifest.raucm])
 

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -131,3 +131,8 @@ gboolean save_slot_status(const gchar *filename, RaucSlotStatus *ss, GError **er
  * @param slotstatus a RaucSlotStatus
  */
 void free_slot_status(RaucSlotStatus *slotstatus);
+
+/**
+ * Frees the memory allocated by a RaucSlot
+ */
+void r_free_slot(gpointer value);

--- a/include/install.h
+++ b/include/install.h
@@ -4,6 +4,23 @@
 
 #include "manifest.h"
 
+#define R_INSTALL_ERROR r_install_error_quark ()
+GQuark r_install_error_quark (void);
+
+typedef enum {
+	R_INSTALL_ERROR_FAILED,
+	R_INSTALL_ERROR_NOSRC,
+	R_INSTALL_ERROR_NODST,
+	R_INSTALL_ERROR_COMPAT_MISMATCH,
+	R_INSTALL_ERROR_REJECTED,
+	R_INSTALL_ERROR_MARK_BOOTABLE,
+	R_INSTALL_ERROR_MARK_NONBOOTABLE,
+	R_INSTALL_ERROR_TARGET_GROUP,
+	R_INSTALL_ERROR_DOWNLOAD_MF,
+	R_INSTALL_ERROR_HANDLER,
+	R_INSTALL_ERROR_NO_SUPPORTED
+} RInstallError;
+
 typedef struct {
 	gchar *name;
 	GSourceFunc notify;

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -120,3 +120,13 @@ gboolean update_manifest(const gchar *dir, gboolean signature, GError **error);
  * @return TRUE on success, FALSE if an error occurred
  */
 gboolean verify_manifest(const gchar *dir, RaucManifest **output, gboolean signature, GError **error);
+
+/**
+ * Frees a rauc image
+ */
+void r_free_image(gpointer data);
+
+/**
+ * Frees a rauc file
+ */
+void r_free_file(gpointer data);

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -5,9 +5,16 @@
 #include <config_file.h>
 
 typedef struct {
+	gboolean pre_install;
+	gboolean install;
+	gboolean post_install;
+} SlotHooks;
+
+typedef struct {
 	gchar* slotclass;
 	RaucChecksum checksum;
 	gchar* filename;
+	SlotHooks hooks;
 } RaucImage;
 
 typedef struct {

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -28,6 +28,8 @@ typedef struct {
 	gchar *handler_name;
 	gchar *handler_args;
 
+	gchar *hook_name;
+
 	GList *images;
 	GList *files;
 } RaucManifest;

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -5,6 +5,10 @@
 #include <config_file.h>
 
 typedef struct {
+	gboolean install_check;
+} InstallHooks;
+
+typedef struct {
 	gboolean pre_install;
 	gboolean install;
 	gboolean post_install;
@@ -36,6 +40,7 @@ typedef struct {
 	gchar *handler_args;
 
 	gchar *hook_name;
+	InstallHooks hooks;
 
 	GList *images;
 	GList *files;

--- a/include/update_handler.h
+++ b/include/update_handler.h
@@ -4,6 +4,6 @@
 
 #include "manifest.h"
 
-typedef gboolean (*img_to_slot_handler) (RaucImage *image, RaucSlot *dest_slot, GError **error);
+typedef gboolean (*img_to_slot_handler) (RaucImage *image, RaucSlot *dest_slot, const gchar *hook_name, GError **error);
 
 img_to_slot_handler get_update_handler(RaucImage *mfimage, RaucSlot  *dest_slot, GError **error);

--- a/include/update_handler.h
+++ b/include/update_handler.h
@@ -4,6 +4,15 @@
 
 #include "manifest.h"
 
+#define R_UPDATE_ERROR r_update_error_quark()
+
+GQuark r_update_error_quark(void);
+
+typedef enum {
+	R_UPDATE_ERROR_FAILED,
+	R_UPDATE_ERROR_NO_HANDLER
+} RUpdateError;
+
 typedef gboolean (*img_to_slot_handler) (RaucImage *image, RaucSlot *dest_slot, const gchar *hook_name, GError **error);
 
 img_to_slot_handler get_update_handler(RaucImage *mfimage, RaucSlot  *dest_slot, GError **error);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -105,9 +105,11 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	c->keyring_path = resolve_path(filename,
 		g_key_file_get_string(key_file, "keyring", "path", NULL));
 
+	/* parse [autoinstall] section */
 	c->autoinstall_path = resolve_path(filename,
 		g_key_file_get_string(key_file, "autoinstall", "path", NULL));
 
+	/* parse [handlers] section */
 	c->systeminfo_handler = resolve_path(filename,
 		g_key_file_get_string(key_file, "handlers", "system-info", NULL));
 

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -8,7 +8,7 @@ G_DEFINE_QUARK(r-config-error-quark, r_config_error)
 
 #define RAUC_SLOT_PREFIX	"slot"
 
-static void free_slot(gpointer value) {
+void r_free_slot(gpointer value) {
 	RaucSlot *slot = (RaucSlot*)value;
 
 	g_clear_pointer(&slot->description, g_free);
@@ -120,7 +120,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 		g_key_file_get_string(key_file, "handlers", "post-install", NULL));
 
 	/* parse [slot.*.#] sections */
-	slots = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, free_slot);
+	slots = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, r_free_slot);
 
 	groups = g_key_file_get_groups(key_file, &group_count);
 	for (gsize i = 0; i < group_count; i++) {

--- a/src/install.c
+++ b/src/install.c
@@ -550,6 +550,7 @@ out:
 
 
 static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bundledir, RaucManifest *manifest, GHashTable *target_group, GError **error) {
+	gchar *hook_name = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	GHashTableIter iter;
@@ -578,6 +579,9 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 			goto early_out;
 		}
 	}
+
+	if (manifest->hook_name)
+		hook_name = g_build_filename(bundledir, manifest->hook_name, NULL);
 
 	r_context_begin_step("update_slots", "Updating slots", g_list_length(manifest->images)*2);
 	install_args_update(args, "Updating slots...");
@@ -687,6 +691,7 @@ copy:
 		res = update_handler(
 			mfimage,
 			dest_slot,
+			hook_name,
 			&ierror);
 		if (!res) {
 			g_propagate_prefixed_error(error, ierror,
@@ -775,6 +780,7 @@ image_out:
 	res = TRUE;
 
 out:
+	g_free(hook_name);
 	r_context_end_step("update_slots", res);
 early_out:
 	return res;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -136,6 +136,10 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 	}
 	g_key_file_remove_group(key_file, "handler", NULL);
 
+	/* parse [hooks] section */
+	raucm->hook_name = manifest_consume_string(key_file, "hooks", "filename", NULL);
+	g_key_file_remove_group(key_file, "hooks", NULL);
+
 	/* parse [image.<slotclass>] and [file.<slotclass>/<destname>] sections */
 	groups = g_key_file_get_groups(key_file, &group_count);
 	for (gsize i = 0; i < group_count; i++) {
@@ -312,6 +316,9 @@ gboolean save_manifest_file(const gchar *filename, RaucManifest *mf, GError **er
 
 	if (mf->handler_args)
 		g_key_file_set_string(key_file, "handler", "args", mf->handler_args);
+
+	if (mf->hook_name)
+		g_key_file_set_string(key_file, "hooks", "filename", mf->hook_name);
 
 	for (GList *l = mf->images; l != NULL; l = l->next) {
 		RaucImage *image = l->data;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -431,7 +431,7 @@ free:
 	return res;
 }
 
-static void free_image(gpointer data) {
+void r_free_image(gpointer data) {
 	RaucImage *image = (RaucImage*) data;
 
 	g_clear_pointer(&image->slotclass, g_free);
@@ -440,7 +440,7 @@ static void free_image(gpointer data) {
 	g_clear_pointer(&image, g_free);
 }
 
-static void free_file(gpointer data) {
+void r_free_file(gpointer data) {
 	RaucFile *file = (RaucFile*) data;
 
 	g_clear_pointer(&file->slotclass, g_free);
@@ -456,8 +456,8 @@ void free_manifest(RaucManifest *manifest) {
 	g_clear_pointer(&manifest->update_version, g_free);
 	g_clear_pointer(&manifest->keyring, g_free);
 	g_clear_pointer(&manifest->handler_name, g_free);
-	g_list_free_full(manifest->images, free_image);
-	g_list_free_full(manifest->files, free_file);
+	g_list_free_full(manifest->images, r_free_image);
+	g_list_free_full(manifest->files, r_free_file);
 	g_clear_pointer(&manifest, g_free);
 }
 

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -540,7 +540,7 @@ static gboolean tar_to_ext4_handler(RaucImage *image, RaucSlot *dest_slot, const
 		goto out;
 	}
 
-	/* mount ubi volume */
+	/* mount ext4 volume */
 	g_message("Mounting ext4 slot %s", dest_slot->device);
 	res = r_mount_slot(dest_slot, &ierror);
 	if (!res) {
@@ -549,7 +549,7 @@ static gboolean tar_to_ext4_handler(RaucImage *image, RaucSlot *dest_slot, const
 		goto unmount_out;
 	}
 
-	/* extract tar into mounted ubi volume */
+	/* extract tar into mounted ext4 volume */
 	g_message("Extracting %s to %s", image->filename, dest_slot->mount_point);
 	res = untar_image(image, dest_slot->mount_point, &ierror);
 	if (!res) {
@@ -567,7 +567,7 @@ static gboolean tar_to_ext4_handler(RaucImage *image, RaucSlot *dest_slot, const
 	}
 
 unmount_out:
-	/* finally umount ubi volume */
+	/* finally umount ext4 volume */
 	g_message("Unmounting ext4 slot %s", dest_slot->device);
 	if (!r_umount_slot(dest_slot, &ierror)) {
 		res = FALSE;
@@ -722,7 +722,6 @@ img_to_slot_handler get_update_handler(RaucImage *mfimage, RaucSlot *dest_slot, 
 	g_message("Checking image type for slot type: %s", dest);
 
 	for (RaucUpdatePair *updatepair = updatepairs; updatepair->handler != NULL; updatepair++) {
-		//g_message("Checking for pattern: %s", (gchar*)l->data);
 		if (g_pattern_match_simple(updatepair->src, src) &&
 		    g_pattern_match_simple(updatepair->dest, dest)) {
 			g_message("Image detected as type: %s", updatepair->src);

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -411,6 +411,15 @@ static gboolean img_to_ubivol_handler(RaucImage *image, RaucSlot *dest_slot, con
 	int out_fd;
 	gboolean res = FALSE;
 
+	/* run slot pre install hook if enabled */
+	if (hook_name && image->hooks.pre_install) {
+		res = run_slot_hook(hook_name, R_SLOT_HOOK_PRE_INSTALL, NULL, dest_slot, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
+	}
+
 	/* open */
 	g_message("opening slot device %s", dest_slot->device);
 	outstream = open_slot_device(dest_slot, &out_fd, &ierror);
@@ -452,6 +461,15 @@ static gboolean tar_to_ubifs_handler(RaucImage *image, RaucSlot *dest_slot, cons
 {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
+
+	/* run slot pre install hook if enabled */
+	if (hook_name && image->hooks.pre_install) {
+		res = mount_and_run_slot_hook(hook_name, R_SLOT_HOOK_PRE_INSTALL, dest_slot, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
+	}
 
 	/* format ubi volume */
 	g_message("Formatting ubifs slot %s", dest_slot->device);
@@ -503,6 +521,15 @@ out:
 static gboolean tar_to_ext4_handler(RaucImage *image, RaucSlot *dest_slot, const gchar *hook_name, GError **error) {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
+
+	/* run slot pre install hook if enabled */
+	if (hook_name && image->hooks.pre_install) {
+		res = run_slot_hook(hook_name, R_SLOT_HOOK_PRE_INSTALL, NULL, dest_slot, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
+	}
 
 	/* format ext4 volume */
 	g_message("Formatting ext4 slot %s", dest_slot->device);
@@ -579,6 +606,15 @@ static gboolean img_to_fs_handler(RaucImage *image, RaucSlot *dest_slot, const g
 	GOutputStream *outstream = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
+
+	/* run slot pre install hook if enabled */
+	if (hook_name && image->hooks.pre_install) {
+		res = mount_and_run_slot_hook(hook_name, R_SLOT_HOOK_PRE_INSTALL, dest_slot, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
+	}
 
 	/* open */
 	g_message("opening slot device %s", dest_slot->device);

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -17,9 +17,7 @@
 #define R_SLOT_HOOK_POST_INSTALL "slot-post-install"
 #define R_SLOT_HOOK_INSTALL "slot-install"
 
-#define R_UPDATE_ERROR r_update_error_quark()
-
-static GQuark r_update_error_quark(void)
+GQuark r_update_error_quark(void)
 {
 	return g_quark_from_static_string("r_update_error_quark");
 }
@@ -37,7 +35,7 @@ static GOutputStream* open_slot_device(RaucSlot *slot, int *fd, GError **error)
 	fd_out = open(g_file_get_path(destslotfile), O_WRONLY);
 
 	if (fd_out == -1) {
-		g_set_error(error, R_UPDATE_ERROR, 0,
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
 				"opening output device failed: %s", strerror(errno));
 		goto out;
 	}
@@ -64,7 +62,7 @@ static gboolean ubifs_ioctl(RaucImage *image, int fd, GError **error)
 	/* set up ubi volume for image copy */
 	ret = ioctl(fd, UBI_IOCVOLUP, &size);
 	if (ret == -1) {
-		g_set_error(error, R_UPDATE_ERROR, 0,
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
 				"ubi volume update failed: %s", strerror(errno));
 		return FALSE;
 	}
@@ -94,7 +92,7 @@ static gboolean copy_raw_image(RaucImage *image, GOutputStream *outstream, GErro
 				"failed splicing data: ");
 		goto out;
 	} else if (size != (gssize)image->checksum.size) {
-		g_set_error_literal(error, R_UPDATE_ERROR, 0,
+		g_set_error_literal(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
 				"image size and written size differ!");
 		goto out;
 	}
@@ -731,7 +729,7 @@ img_to_slot_handler get_update_handler(RaucImage *mfimage, RaucSlot *dest_slot, 
 	}
 
 	if (handler == NULL)  {
-		g_set_error(error, R_UPDATE_ERROR, 1, "Unsupported image %s for slot type %s",
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_NO_HANDLER, "Unsupported image %s for slot type %s",
 			    mfimage->filename, dest);
 		goto out;
 	}

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -93,8 +93,8 @@ static gboolean copy_raw_image(RaucImage *image, GOutputStream *outstream, GErro
 				"failed splicing data: ");
 		goto out;
 	} else if (size != (gssize)image->checksum.size) {
-		g_set_error_literal(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
-				"image size and written size differ!");
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"written size (%"G_GSIZE_FORMAT") != image size (%"G_GSIZE_FORMAT")", size, (gssize)image->checksum.size);
 		goto out;
 	}
 

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -151,6 +151,7 @@ static gboolean ext4_format_slot(RaucSlot *dest_slot, GError **error)
 	GPtrArray *args = g_ptr_array_new_full(4, g_free);
 
 	g_ptr_array_add(args, g_strdup("mkfs.ext4"));
+	g_ptr_array_add(args, g_strdup("-F"));
 	if (strlen(dest_slot->name) <= 16) {
 		g_ptr_array_add(args, g_strdup("-L"));
 		g_ptr_array_add(args, g_strdup(dest_slot->name));

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -75,6 +75,7 @@ static gboolean copy_raw_image(RaucImage *image, GOutputStream *outstream, GErro
 	GError *ierror = NULL;
 	gssize size;
 	GFile *srcimagefile = g_file_new_for_path(image->filename);
+	gboolean res = FALSE;
 
 	GInputStream *instream = (GInputStream*)g_file_read(srcimagefile, NULL, &ierror);
 	if (instream == NULL) {
@@ -97,10 +98,12 @@ static gboolean copy_raw_image(RaucImage *image, GOutputStream *outstream, GErro
 		goto out;
 	}
 
+	res = TRUE;
+
 out:
 	g_clear_object(&instream);
 	g_clear_object(&srcimagefile);
-	return TRUE;
+	return res;
 }
 
 static gboolean ubifs_format_slot(RaucSlot *dest_slot, GError **error)

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -594,6 +594,15 @@ static gboolean img_to_nand_handler(RaucImage *image, RaucSlot *dest_slot, const
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
+	/* run slot pre install hook if enabled */
+	if (hook_name && image->hooks.pre_install) {
+		res = run_slot_hook(hook_name, R_SLOT_HOOK_PRE_INSTALL, NULL, dest_slot, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
+	}
+
 	/* erase */
 	g_message("erasing slot device %s", dest_slot->device);
 	res = nand_format_slot(dest_slot->device, &ierror);
@@ -608,6 +617,15 @@ static gboolean img_to_nand_handler(RaucImage *image, RaucSlot *dest_slot, const
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;
+	}
+
+	/* run slot post install hook if enabled */
+	if (hook_name && image->hooks.post_install) {
+		res = run_slot_hook(hook_name, R_SLOT_HOOK_POST_INSTALL, NULL, dest_slot, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
 	}
 
 out:
@@ -663,6 +681,15 @@ static gboolean img_to_raw_handler(RaucImage *image, RaucSlot *dest_slot, const 
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
+	/* run slot pre install hook if enabled */
+	if (hook_name && image->hooks.pre_install) {
+		res = run_slot_hook(hook_name, R_SLOT_HOOK_PRE_INSTALL, NULL, dest_slot, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
+	}
+
 	/* open */
 	g_message("opening slot device %s", dest_slot->device);
 	outstream = open_slot_device(dest_slot, NULL, &ierror);
@@ -677,6 +704,15 @@ static gboolean img_to_raw_handler(RaucImage *image, RaucSlot *dest_slot, const 
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;
+	}
+
+	/* run slot post install hook if enabled */
+	if (hook_name && image->hooks.post_install) {
+		res = run_slot_hook(hook_name, R_SLOT_HOOK_POST_INSTALL, NULL, dest_slot, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
 	}
 
 out:

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -27,7 +27,7 @@ static void bundle_fixture_set_up(BundleFixture *fixture,
 					 1024*1024, "/dev/urandom") == 0);
 	g_assert(test_prepare_dummy_file(fixture->tmpdir, "content/appfs.ext4",
 				         64*1024, "/dev/urandom") == 0);
-	g_assert(test_prepare_manifest_file(fixture->tmpdir, "content/manifest.raucm", FALSE) == 0);
+	g_assert(test_prepare_manifest_file(fixture->tmpdir, "content/manifest.raucm", FALSE, FALSE) == 0);
 }
 
 static void bundle_fixture_tear_down(BundleFixture *fixture,

--- a/test/common.c
+++ b/test/common.c
@@ -133,6 +133,19 @@ int test_rmdir(const gchar *dirname, const gchar *filename) {
 	return res;
 }
 
+int test_remove(const gchar *dirname, const gchar *filename) {
+	gchar *path;
+	int res;
+
+	path = g_build_filename(dirname, filename, NULL);
+	g_assert_nonnull(path);
+
+	res = g_remove(path);
+
+	g_free(path);
+	return res;
+}
+
 gboolean test_rm_tree(const gchar *dirname, const gchar *filename) {
 	gchar *path;
 	gboolean res;

--- a/test/common.c
+++ b/test/common.c
@@ -146,7 +146,7 @@ gboolean test_rm_tree(const gchar *dirname, const gchar *filename) {
 	return res;
 }
 
-int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, gboolean custom_handler) {
+int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, gboolean custom_handler, gboolean hook) {
 	gchar *path = g_build_filename(dirname, filename, NULL);
 	RaucManifest *rm = g_new0(RaucManifest, 1);
 	RaucImage *img;
@@ -156,6 +156,9 @@ int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, gboo
 
 	if (custom_handler)
 		rm->handler_name = g_strdup("custom_handler.sh");
+
+	if (hook)
+		rm->hook_name = g_strdup("hook.sh");
 
 	img = g_new0(RaucImage, 1);
 

--- a/test/common.c
+++ b/test/common.c
@@ -146,7 +146,7 @@ gboolean test_rm_tree(const gchar *dirname, const gchar *filename) {
 	return res;
 }
 
-int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, gboolean custom_handler, gboolean hook) {
+int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, gboolean custom_handler, gboolean hooks) {
 	gchar *path = g_build_filename(dirname, filename, NULL);
 	RaucManifest *rm = g_new0(RaucManifest, 1);
 	RaucImage *img;
@@ -157,13 +157,16 @@ int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, gboo
 	if (custom_handler)
 		rm->handler_name = g_strdup("custom_handler.sh");
 
-	if (hook)
+	if (hooks) {
 		rm->hook_name = g_strdup("hook.sh");
+	}
 
 	img = g_new0(RaucImage, 1);
 
 	img->slotclass = g_strdup("rootfs");
 	img->filename = g_strdup("rootfs.ext4");
+	if (hooks)
+		img->hooks.post_install = TRUE;
 	rm->images = g_list_append(rm->images, img);
 
 	img = g_new0(RaucImage, 1);

--- a/test/common.h
+++ b/test/common.h
@@ -12,7 +12,7 @@ int test_prepare_dummy_file(const gchar *dirname, const gchar *filename,
 int test_mkdir_relative(const gchar *dirname, const gchar *filename, int mode);
 int test_rmdir(const gchar *dirname, const gchar *filename);
 gboolean test_rm_tree(const gchar *dirname, const gchar *filename);
-int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, gboolean custom_handler);
+int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, gboolean custom_handler, gboolean hook);
 gboolean test_make_filesystem(const gchar *dirname, const gchar *filename);
 gboolean test_mount(const gchar *src, const gchar *dest);
 gboolean test_umount(const gchar *dirname, const gchar *mountpoint);

--- a/test/common.h
+++ b/test/common.h
@@ -11,6 +11,7 @@ int test_prepare_dummy_file(const gchar *dirname, const gchar *filename,
 			    gsize size, const gchar *source);
 int test_mkdir_relative(const gchar *dirname, const gchar *filename, int mode);
 int test_rmdir(const gchar *dirname, const gchar *filename);
+int test_remove(const gchar *dirname, const gchar *filename);
 gboolean test_rm_tree(const gchar *dirname, const gchar *filename);
 int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, gboolean custom_handler, gboolean hook);
 gboolean test_make_filesystem(const gchar *dirname, const gchar *filename);

--- a/test/install-content/hook.sh
+++ b/test/install-content/hook.sh
@@ -15,7 +15,7 @@ case "$1" in
 		test -n "$RAUC_MF_COMPATIBLE" || die_error "missing RAUC_MF_COMPATIBLE"
 		test -n "$RAUC_SYSTEM_COMPATIBLE" || die_error "missing RAUC_SYSTEM_COMPATIBLE"
 		echo "No, I won't install this!" 1>&2
-		exit 1
+		exit 10
 		;;
 	slot-post-install)
 		test -n "$RAUC_SLOT_NAME" || die_error "missing RAUC_SLOT_NAME"

--- a/test/install-content/hook.sh
+++ b/test/install-content/hook.sh
@@ -9,15 +9,33 @@ die_error() {
 	exit 1
 }
 
-test "$1" = "slot-post-install" || exit 0
-
 test -n "$RAUC_SLOT_NAME" || die_error "missing RAUC_SLOT_NAME"
 test -n "$RAUC_SLOT_CLASS" || die_error "missing RAUC_SLOT_CLASS"
 
-# only rootfs needs to be handled
-test "$RAUC_SLOT_CLASS" = "rootfs" || exit 0
+case "$1" in
+	slot-post-install)
+		# only rootfs needs to be handled
+		test "$RAUC_SLOT_CLASS" = "rootfs" || exit 0
 
-test -d "$RAUC_SLOT_MOUNT_POINT" || die_error "missing RAUC_SLOT_MOUNT_POINT"
+		test -d "$RAUC_SLOT_MOUNT_POINT" || die_error "missing RAUC_SLOT_MOUNT_POINT"
 
-echo "$RAUC_SLOT_MOUNT_POINT/hook-stamp"
-touch "$RAUC_SLOT_MOUNT_POINT/hook-stamp"
+		echo "$RAUC_SLOT_MOUNT_POINT/hook-stamp"
+		touch "$RAUC_SLOT_MOUNT_POINT/hook-stamp"
+		;;
+	slot-install)
+		echo "RAUC_IMAGE_PATH: $RAUC_IMAGE_PATH"
+		echo "RAUC_SLOT_DEVICE: $RAUC_SLOT_DEVICE"
+		echo "RAUC_SLOT_MOUNT_POINT: $RAUC_SLOT_MOUNT_POINT"
+		echo "RAUC_MOUNT_PREFIX: $RAUC_MOUNT_PREFIX"
+		echo "$RAUC_MOUNT_PREFIX/hook-slot"
+		mkdir "$RAUC_MOUNT_PREFIX/hook-slot"
+		mount "$RAUC_SLOT_DEVICE" "$RAUC_MOUNT_PREFIX/hook-slot"
+		echo "$RAUC_MOUNT_PREFIX/hook-slot/hook-install"
+		touch "$RAUC_MOUNT_PREFIX/hook-slot/hook-install"
+		umount "$RAUC_MOUNT_PREFIX/hook-slot"
+		rmdir  "$RAUC_MOUNT_PREFIX/hook-slot"
+		;;
+	*)
+		exit 1
+		;;
+esac

--- a/test/install-content/hook.sh
+++ b/test/install-content/hook.sh
@@ -6,14 +6,21 @@ NAME="$0"
 
 die_error() {
 	echo "$NAME ERROR: $1"
-	exit 1
+	exit 2
 }
 
-test -n "$RAUC_SLOT_NAME" || die_error "missing RAUC_SLOT_NAME"
-test -n "$RAUC_SLOT_CLASS" || die_error "missing RAUC_SLOT_CLASS"
 
 case "$1" in
+	install-check)
+		test -n "$RAUC_MF_COMPATIBLE" || die_error "missing RAUC_MF_COMPATIBLE"
+		test -n "$RAUC_SYSTEM_COMPATIBLE" || die_error "missing RAUC_SYSTEM_COMPATIBLE"
+		echo "No, I won't install this!" 1>&2
+		exit 1
+		;;
 	slot-post-install)
+		test -n "$RAUC_SLOT_NAME" || die_error "missing RAUC_SLOT_NAME"
+		test -n "$RAUC_SLOT_CLASS" || die_error "missing RAUC_SLOT_CLASS"
+
 		# only rootfs needs to be handled
 		test "$RAUC_SLOT_CLASS" = "rootfs" || exit 0
 
@@ -23,6 +30,9 @@ case "$1" in
 		touch "$RAUC_SLOT_MOUNT_POINT/hook-stamp"
 		;;
 	slot-install)
+		test -n "$RAUC_SLOT_NAME" || die_error "missing RAUC_SLOT_NAME"
+		test -n "$RAUC_SLOT_CLASS" || die_error "missing RAUC_SLOT_CLASS"
+
 		echo "RAUC_IMAGE_PATH: $RAUC_IMAGE_PATH"
 		echo "RAUC_SLOT_DEVICE: $RAUC_SLOT_DEVICE"
 		echo "RAUC_SLOT_MOUNT_POINT: $RAUC_SLOT_MOUNT_POINT"

--- a/test/install-content/hook.sh
+++ b/test/install-content/hook.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+NAME="$0"
+
+die_error() {
+	echo "$NAME ERROR: $1"
+	exit 1
+}
+
+test "$1" = "slot-post-install" || exit 0
+
+test -n "$RAUC_SLOT_NAME" || die_error "missing RAUC_SLOT_NAME"
+test -n "$RAUC_SLOT_CLASS" || die_error "missing RAUC_SLOT_CLASS"
+
+# only rootfs needs to be handled
+test "$RAUC_SLOT_CLASS" = "rootfs" || exit 0
+
+test -d "$RAUC_SLOT_MOUNT_POINT" || die_error "missing RAUC_SLOT_MOUNT_POINT"
+
+echo "$RAUC_SLOT_MOUNT_POINT/hook-stamp"
+touch "$RAUC_SLOT_MOUNT_POINT/hook-stamp"

--- a/test/install.c
+++ b/test/install.c
@@ -149,7 +149,7 @@ static void set_up_bundle(InstallFixture *fixture,
 					 SLOT_SIZE, "/dev/zero") == 0);
 	g_assert_true(test_make_filesystem(fixture->tmpdir, "content/rootfs.ext4"));
 	g_assert_true(test_make_filesystem(fixture->tmpdir, "content/appfs.ext4"));
-	g_assert(test_prepare_manifest_file(fixture->tmpdir, "content/manifest.raucm", FALSE, FALSE) == 0);
+	g_assert(test_prepare_manifest_file(fixture->tmpdir, "content/manifest.raucm", FALSE, hook) == 0);
 
 	/* Make images user-writable */
 	test_make_slot_user_writable(fixture->tmpdir, "content/rootfs.ext4");

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -15,6 +15,7 @@ static void manifest_check_common(RaucManifest *rm) {
 	g_assert_cmpstr(rm->keyring, ==, "release.tar");
 	g_assert_cmpstr(rm->handler_name, ==, "custom_handler.sh");
 	g_assert_cmpstr(rm->handler_args, ==, "--dummy1 --dummy2");
+	g_assert_cmpstr(rm->hook_name, ==, "hook.sh");
 	g_assert_nonnull(rm->images);
 
 	g_assert_cmpuint(g_list_length(rm->images), ==, 2);
@@ -95,6 +96,7 @@ static void test_save_load_manifest(void)
 	rm->keyring = g_strdup("mykeyring.tar");
 	rm->handler_name = g_strdup("myhandler.sh");
 	rm->handler_args = g_strdup("--foo");
+	rm->hook_name = g_strdup("hook.sh");
 
 	new_image = g_new0(RaucImage, 1);
 
@@ -136,6 +138,7 @@ static void test_save_load_manifest(void)
 	g_assert_cmpstr(rm->keyring, ==, "mykeyring.tar");
 	g_assert_cmpstr(rm->handler_name, ==, "myhandler.sh");
 	g_assert_cmpstr(rm->handler_args, ==, "--foo --dummy1 --dummy2");
+	g_assert_cmpstr(rm->hook_name, ==, "hook.sh");
 
 	g_assert_cmpuint(g_list_length(rm->images), ==, 2);
 	g_assert_cmpuint(g_list_length(rm->files), ==, 1);

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -104,6 +104,8 @@ static void test_save_load_manifest(void)
 	new_image->checksum.type = G_CHECKSUM_SHA256;
 	new_image->checksum.digest = g_strdup("c8af04e62bad4ab75dafd22119026e5e3943f385bdcbe7731a4938102453754c");
 	new_image->filename = g_strdup("myrootimg.ext4");
+	new_image->hooks.pre_install = TRUE;
+	new_image->hooks.post_install = TRUE;
 	rm->images = g_list_append(rm->images, new_image);
 
 	new_image = g_new0(RaucImage, 1);
@@ -159,6 +161,9 @@ static void test_save_load_manifest(void)
 		g_assert_nonnull(file->checksum.digest);
 		g_assert_nonnull(file->filename);
 	}
+
+	g_assert_true(((RaucImage*)g_list_nth_data(rm->images, 0))->hooks.pre_install);
+	g_assert_true(((RaucImage*)g_list_nth_data(rm->images, 0))->hooks.post_install);
 
 	free_manifest(rm);
 }

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -97,6 +97,7 @@ static void test_save_load_manifest(void)
 	rm->handler_name = g_strdup("myhandler.sh");
 	rm->handler_args = g_strdup("--foo");
 	rm->hook_name = g_strdup("hook.sh");
+	rm->hooks.install_check = TRUE;
 
 	new_image = g_new0(RaucImage, 1);
 
@@ -162,8 +163,11 @@ static void test_save_load_manifest(void)
 		g_assert_nonnull(file->filename);
 	}
 
+	g_assert_nonnull(g_list_nth_data(rm->images, 0));
 	g_assert_true(((RaucImage*)g_list_nth_data(rm->images, 0))->hooks.pre_install);
 	g_assert_true(((RaucImage*)g_list_nth_data(rm->images, 0))->hooks.post_install);
+
+	g_assert_true(rm->hooks.install_check);
 
 	free_manifest(rm);
 }

--- a/test/manifest.raucm
+++ b/test/manifest.raucm
@@ -10,6 +10,9 @@ archive=release.tar
 [handler]
 filename=custom_handler.sh
 
+[hooks]
+filename=hook.sh
+
 [image.rootfs]
 sha256=b14c1457dc10469418b4154fef29a90e1ffb4dddd308bf0f2456d436963ef5b3
 filename=rootfs.ext4

--- a/test/manifest.raucm
+++ b/test/manifest.raucm
@@ -16,6 +16,7 @@ filename=hook.sh
 [image.rootfs]
 sha256=b14c1457dc10469418b4154fef29a90e1ffb4dddd308bf0f2456d436963ef5b3
 filename=rootfs.ext4
+hooks=pre-install;post-install
 
 [image.appfs]
 sha256=ecf4c031d01cb9bfa9aa5ecfce93efcf9149544bdbf91178d2c2d9d1d24076ca

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -27,6 +27,7 @@ static void test_get_update_handler(UpdateHandlerFixture *fixture, gconstpointer
 	RaucSlot *targetslot;
 	img_to_slot_handler handler;
 	UpdateHandlerTestPair *test_pair = (UpdateHandlerTestPair*) user_data;
+	GError *ierror = NULL;
 
 	image = g_new0(RaucImage, 1);
 	image->slotclass = g_strdup("rootfs");
@@ -38,11 +39,14 @@ static void test_get_update_handler(UpdateHandlerFixture *fixture, gconstpointer
 	targetslot->device = g_strdup("/dev/null");
 	targetslot->type = g_strdup(test_pair->slottype);
 
-	handler = get_update_handler(image, targetslot, NULL);
-	if (test_pair->success)
+	handler = get_update_handler(image, targetslot, &ierror);
+	if (test_pair->success) {
+		g_assert_no_error(ierror);
 		g_assert_nonnull(handler);
-	else
+	} else {
+		g_assert_error(ierror, R_UPDATE_ERROR, R_UPDATE_ERROR_NO_HANDLER);
 		g_assert_null(handler);
+	}
 }
 
 /* Test update_handler/get_custom_handler:
@@ -55,6 +59,7 @@ static void test_get_custom_update_handler(UpdateHandlerFixture *fixture, gconst
 	RaucImage *image;
 	RaucSlot *targetslot;
 	img_to_slot_handler handler;
+	GError *ierror = NULL;
 
 	image = g_new0(RaucImage, 1);
 	image->slotclass = g_strdup("rootfs");
@@ -67,7 +72,8 @@ static void test_get_custom_update_handler(UpdateHandlerFixture *fixture, gconst
 	targetslot->device = g_strdup("/dev/null");
 	targetslot->type = g_strdup("nand");
 
-	handler = get_update_handler(image, targetslot, NULL);
+	handler = get_update_handler(image, targetslot, &ierror);
+	g_assert_no_error(ierror);
 	g_assert_nonnull(handler);
 }
 

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -1,8 +1,11 @@
 #include <locale.h>
 #include <glib.h>
+#include <gio/gio.h>
+#include <glib/gstdio.h>
 
 #include "update_handler.h"
 #include "manifest.h"
+#include "common.h"
 
 typedef struct {
 	gchar *tmpdir;
@@ -77,6 +80,117 @@ static void test_get_custom_update_handler(UpdateHandlerFixture *fixture, gconst
 	g_assert_nonnull(handler);
 }
 
+#define SLOT_SIZE (10*1024*1024)
+#define IMAGE_SIZE (10*1024*1024)
+
+static void update_handler_fixture_set_up(UpdateHandlerFixture *fixture,
+		gconstpointer user_data)
+{
+	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+	g_assert_nonnull(fixture->tmpdir);
+
+
+	g_assert(test_prepare_dummy_file(fixture->tmpdir, "rootfs-0",
+				         SLOT_SIZE, "/dev/zero") == 0);
+
+
+}
+
+static void update_handler_fixture_tear_down(UpdateHandlerFixture *fixture,
+		gconstpointer user_data)
+{
+	if (!fixture->tmpdir)
+		return;
+
+	g_assert(test_remove(fixture->tmpdir, "rootfs-0") == 0);
+	g_assert(test_rmdir(fixture->tmpdir, "") == 0);
+}
+
+static gsize get_file_size(gchar* filename, GError **error) {
+	GError *ierror = NULL;
+	GFile *file = NULL;
+	GFileInputStream *filestream = NULL;
+	gsize size = 0;
+	gboolean res = FALSE;
+
+	file = g_file_new_for_path(filename);
+	filestream = g_file_read(file, NULL, &ierror);
+	if (filestream == NULL) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed to open bundle for reading: ");
+		goto out;
+	}
+
+	res = g_seekable_seek(G_SEEKABLE(filestream),
+			      0, G_SEEK_END, NULL, &ierror);
+	if (!res) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed to seek to end of bundle: ");
+		goto out;
+	}
+
+	size = g_seekable_tell((GSeekable *)filestream);
+
+out:
+	g_clear_object(&filestream);
+	g_clear_object(&file);
+
+	return size;
+}
+
+static void test_update_handler(UpdateHandlerFixture *fixture,
+		gconstpointer user_data)
+{
+	UpdateHandlerTestPair *test_pair = (UpdateHandlerTestPair*) user_data;
+	gchar *slotpath, *imagepath;
+	RaucImage *image;
+	RaucSlot *targetslot;
+	img_to_slot_handler handler;
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+
+	/* prepare image and slot information */
+	slotpath = g_build_filename(fixture->tmpdir, "rootfs-0", NULL);
+	imagepath = g_build_filename(fixture->tmpdir, "image.img", NULL);
+
+	image = g_new0(RaucImage, 1);
+	image->slotclass = g_strdup("rootfs");
+	image->filename = g_strdup(imagepath);
+	image->checksum.size = IMAGE_SIZE;
+
+	g_assert(test_prepare_dummy_file(fixture->tmpdir, "image.img",
+				         IMAGE_SIZE, "/dev/zero") == 0);
+
+	targetslot = g_new0(RaucSlot, 1);
+	targetslot->name = g_strdup("rootfs.0");
+	targetslot->sclass = g_strdup("rootfs");
+	targetslot->device = g_strdup(slotpath);
+	targetslot->type = g_strdup(test_pair->slottype);
+
+	/* get handler for this */
+	handler = get_update_handler(image, targetslot, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_nonnull(handler);
+
+	/* Run to perform an update */
+	res = handler(image, targetslot, NULL, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+
+	g_assert_cmpint(get_file_size(imagepath, NULL), ==, IMAGE_SIZE);
+
+	g_remove(imagepath);
+
+	g_free(slotpath);
+	g_free(imagepath);
+	r_free_image(image);
+	r_free_slot(targetslot);
+}
+
 int main(int argc, char *argv[])
 {
 	UpdateHandlerTestPair testpair_matrix[] = {
@@ -84,6 +198,8 @@ int main(int argc, char *argv[])
 		{"ext4", "ext4", TRUE},
 		{"ubifs", "tar.bz2", TRUE},
 		{"ubifs", "ext4", FALSE},
+		{"raw", "img", TRUE},
+		{"ext4", "img", TRUE},
 		{0}
 	};
 	setlocale(LC_ALL, "C");
@@ -124,6 +240,20 @@ int main(int argc, char *argv[])
 			NULL,
 			test_get_custom_update_handler,
 			NULL);
+
+	g_test_add("/update_handler/update_handler/img_to_raw",
+			UpdateHandlerFixture,
+			&testpair_matrix[4],
+			update_handler_fixture_set_up,
+			test_update_handler,
+			update_handler_fixture_tear_down);
+
+	g_test_add("/update_handler/update_handler/img_to_ext4",
+			UpdateHandlerFixture,
+			&testpair_matrix[5],
+			update_handler_fixture_set_up,
+			test_update_handler,
+			update_handler_fixture_tear_down);
 
 	return g_test_run();
 }

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -43,6 +43,27 @@ static void test_get_update_handler(UpdateHandlerFixture *fixture, gconstpointer
 		g_assert_null(handler);
 }
 
+static void test_get_custom_update_handler(UpdateHandlerFixture *fixture, gconstpointer user_data)
+{
+	RaucImage *image;
+	RaucSlot *targetslot;
+	img_to_slot_handler handler;
+
+	image = g_new0(RaucImage, 1);
+	image->slotclass = g_strdup("rootfs");
+	image->filename = g_strdup("rootfs.custom");
+	image->hooks.install = TRUE;
+
+	targetslot = g_new0(RaucSlot, 1);
+	targetslot->name = g_strdup("rootfs.0");
+	targetslot->sclass = g_strdup("rootfs");
+	targetslot->device = g_strdup("/dev/null");
+	targetslot->type = g_strdup("nand");
+
+	handler = get_update_handler(image, targetslot, NULL);
+	g_assert_nonnull(handler);
+}
+
 int main(int argc, char *argv[])
 {
 	UpdateHandlerTestPair testpair_matrix[] = {
@@ -82,6 +103,13 @@ int main(int argc, char *argv[])
 			&testpair_matrix[3],
 			NULL,
 			test_get_update_handler,
+			NULL);
+
+	g_test_add("/update_handler/get_custom_handler",
+			UpdateHandlerFixture,
+			NULL,
+			NULL,
+			test_get_custom_update_handler,
 			NULL);
 
 	return g_test_run();

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -255,6 +255,10 @@ static void test_update_handler(UpdateHandlerFixture *fixture,
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
+	/* needs to run as root */
+	if (!test_running_as_root())
+		return;
+
 	/* prepare image and slot information */
 	imagename = g_strconcat("image.", test_pair->imagetype, NULL);
 	slotpath = g_build_filename(fixture->tmpdir, "rootfs-0", NULL);

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -17,7 +17,9 @@ typedef struct {
 	gboolean success;
 } UpdateHandlerTestPair;
 
-/* Allows to test several source image / slot type combinations to either have
+/* Test update_handler/get_handler/<combination>:
+ *
+ * Allows to test several source image / slot type combinations to either have
  * a valid handler or not */
 static void test_get_update_handler(UpdateHandlerFixture *fixture, gconstpointer user_data)
 {
@@ -43,6 +45,11 @@ static void test_get_update_handler(UpdateHandlerFixture *fixture, gconstpointer
 		g_assert_null(handler);
 }
 
+/* Test update_handler/get_custom_handler:
+ *
+ * Tests for get_update_handler() returning hook script handler if 'install'
+ * hook is registered for image.
+ */
 static void test_get_custom_update_handler(UpdateHandlerFixture *fixture, gconstpointer user_data)
 {
 	RaucImage *image;

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -6,6 +6,8 @@
 #include "update_handler.h"
 #include "manifest.h"
 #include "common.h"
+#include "context.h"
+#include "mount.h"
 
 typedef struct {
 	gchar *tmpdir;
@@ -82,6 +84,7 @@ static void test_get_custom_update_handler(UpdateHandlerFixture *fixture, gconst
 
 #define SLOT_SIZE (10*1024*1024)
 #define IMAGE_SIZE (10*1024*1024)
+#define FILE_SIZE (10*1024)
 
 static void update_handler_fixture_set_up(UpdateHandlerFixture *fixture,
 		gconstpointer user_data)
@@ -142,11 +145,85 @@ out:
 	return size;
 }
 
+static gboolean tar_image(const gchar *dest, const gchar *dir, GError **error)
+{
+	GSubprocess *sproc = NULL;
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+	GPtrArray *args = g_ptr_array_new_full(5, g_free);
+
+	g_ptr_array_add(args, g_strdup("tar"));
+	g_ptr_array_add(args, g_strdup("cf"));
+	g_ptr_array_add(args, g_strdup(dest));
+	g_ptr_array_add(args, g_strdup("-C"));
+	g_ptr_array_add(args, g_strdup(dir));
+	g_ptr_array_add(args, g_strdup("."));
+	g_ptr_array_add(args, NULL);
+
+	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
+				  G_SUBPROCESS_FLAGS_NONE, &ierror);
+	if (sproc == NULL) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed to start tar compress: ");
+		goto out;
+	}
+
+	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	if (!res) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed to run tar compress: ");
+		goto out;
+	}
+
+out:
+	g_ptr_array_unref(args);
+	g_clear_pointer(&sproc, g_object_unref);
+	return res;
+}
+
+/**
+ * Create dummy archive.
+ *
+ * @path where to build
+ * @path destination name
+ * @filename name of dummy file in archive
+ */
+static gboolean test_prepare_dummy_archive(const gchar *path, const gchar *archname, const gchar *filename)
+{
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+	gchar *archpath = NULL, *contentpath = NULL;
+
+	archpath = g_build_filename(path, archname, NULL);
+	contentpath = g_build_filename(path, "content", NULL);
+
+	g_assert(g_mkdir(contentpath, 0777) == 0);
+	g_assert(test_prepare_dummy_file(contentpath, filename,
+				FILE_SIZE, "/dev/zero") == 0);
+
+	/* tar file to pseudo image */
+	res = tar_image(archpath, contentpath, &ierror);
+	if (!res) {
+		g_warning("%s", ierror->message);
+		goto out;
+	}
+
+	res = TRUE;
+out:
+	g_clear_pointer(&contentpath, g_free);
+	g_clear_pointer(&archpath, g_free);
+	return res;
+}
+
 static void test_update_handler(UpdateHandlerFixture *fixture,
 		gconstpointer user_data)
 {
 	UpdateHandlerTestPair *test_pair = (UpdateHandlerTestPair*) user_data;
-	gchar *slotpath, *imagepath;
+	gchar *slotpath, *imagename, *imagepath, *mountprefix;
 	RaucImage *image;
 	RaucSlot *targetslot;
 	img_to_slot_handler handler;
@@ -154,22 +231,38 @@ static void test_update_handler(UpdateHandlerFixture *fixture,
 	gboolean res = FALSE;
 
 	/* prepare image and slot information */
+	imagename = g_strconcat("image.", test_pair->imagetype, NULL);
 	slotpath = g_build_filename(fixture->tmpdir, "rootfs-0", NULL);
-	imagepath = g_build_filename(fixture->tmpdir, "image.img", NULL);
+	imagepath = g_build_filename(fixture->tmpdir, imagename, NULL);
 
+	/* create source image */
 	image = g_new0(RaucImage, 1);
 	image->slotclass = g_strdup("rootfs");
 	image->filename = g_strdup(imagepath);
 	image->checksum.size = IMAGE_SIZE;
 
-	g_assert(test_prepare_dummy_file(fixture->tmpdir, "image.img",
-				         IMAGE_SIZE, "/dev/zero") == 0);
+	if (g_strcmp0(test_pair->imagetype, "img") == 0) {
+		g_assert(test_prepare_dummy_file(fixture->tmpdir, "image.img",
+					IMAGE_SIZE, "/dev/zero") == 0);
+	} else if (g_strcmp0(test_pair->imagetype, "tar.bz2") == 0) {
+		g_assert_true(test_prepare_dummy_archive(fixture->tmpdir, "image.tar.bz2", "testfile.txt"));
+	} else {
+		g_assert_not_reached();
+	}
 
+	/* create target slot */
 	targetslot = g_new0(RaucSlot, 1);
 	targetslot->name = g_strdup("rootfs.0");
 	targetslot->sclass = g_strdup("rootfs");
 	targetslot->device = g_strdup(slotpath);
 	targetslot->type = g_strdup(test_pair->slottype);
+
+	/* Set mount path to current temp dir */
+	mountprefix = g_build_filename(fixture->tmpdir, "testmount", NULL);
+	g_assert_nonnull(mountprefix);
+	r_context_conf()->mountprefix = mountprefix;
+	r_context();
+	g_assert(g_mkdir(mountprefix, 0777) == 0);
 
 	/* get handler for this */
 	handler = get_update_handler(image, targetslot, &ierror);
@@ -181,12 +274,22 @@ static void test_update_handler(UpdateHandlerFixture *fixture,
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 
-	g_assert_cmpint(get_file_size(imagepath, NULL), ==, IMAGE_SIZE);
+	if (g_strcmp0(test_pair->imagetype, "img") == 0) {
+		g_assert_cmpint(get_file_size(imagepath, NULL), ==, IMAGE_SIZE);
+	} else if (g_strcmp0(test_pair->imagetype, "tar.bz2") == 0) {
+		gchar *testpath = g_build_filename(mountprefix, "testfile.txt", NULL);
+		g_assert(test_mount(slotpath, mountprefix));
+		g_assert_true(g_file_test(testpath, G_FILE_TEST_IS_REGULAR));
+		g_assert(r_umount(slotpath, NULL));
+		g_free(testpath);
+	}
 
 	g_remove(imagepath);
 
 	g_free(slotpath);
+	g_free(imagename);
 	g_free(imagepath);
+	g_free(mountprefix);
 	r_free_image(image);
 	r_free_slot(targetslot);
 }
@@ -200,6 +303,7 @@ int main(int argc, char *argv[])
 		{"ubifs", "ext4", FALSE},
 		{"raw", "img", TRUE},
 		{"ext4", "img", TRUE},
+		{"ext4", "tar.bz2", TRUE},
 		{0}
 	};
 	setlocale(LC_ALL, "C");
@@ -251,6 +355,13 @@ int main(int argc, char *argv[])
 	g_test_add("/update_handler/update_handler/img_to_ext4",
 			UpdateHandlerFixture,
 			&testpair_matrix[5],
+			update_handler_fixture_set_up,
+			test_update_handler,
+			update_handler_fixture_tear_down);
+
+	g_test_add("/update_handler/update_handler/tar_to_ext4",
+			UpdateHandlerFixture,
+			&testpair_matrix[6],
 			update_handler_fixture_set_up,
 			test_update_handler,
 			update_handler_fixture_tear_down);


### PR DESCRIPTION
This patch series introduces hooks to rauc.

In contrast to handlers, hooks can be specified from your respective installation bundle and will be executed only for the current installation.

All hooks run from a single script which gets the hook name passed as a parameter. All further informations required will be passed via environment variables as known form handlers.

Hooks need to be registered explicitly. Some may work on a per slot/image base while some may perform more installation-global operations.

Currently introduced hooks are:

Per slots
* pre-install
* post-install
* install

Per update
* install-check

An example of how to specify them in the manifest:

```cfg
[hooks]
filename=hooks.sh
hooks=install-check

[image.rootfs]
filename=...
...
hooks=pre-install;post-install
```