### PR TITLE
bundle: fix format specifier for printing sigsize

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -298,14 +298,14 @@ gboolean check_bundle(const gchar *bundlename, gsize *size, gboolean verify, GEr
 	/* sanity check: signature should be smaller than bundle size */
 	if (sigsize > (guint64)offset) {
 		g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE,
-				"signature size sanity check failed: %"G_GSIZE_FORMAT" exceeds bundle size", sigsize);
+				"signature size sanity check failed: %"G_GUINT64_FORMAT" exceeds bundle size", sigsize);
 		res = FALSE;
 		goto out;
 	}
 	/* sanity check: signature should be smaller than 64kiB */
 	if (sigsize > 0x4000000) {
 		g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE,
-				"signature size sanity check failed: %"G_GSIZE_FORMAT" exceeds 64KiB", sigsize);
+				"signature size sanity check failed: %"G_GUINT64_FORMAT" exceeds 64KiB", sigsize);
 		res = FALSE;
 		goto out;
 	}


### PR DESCRIPTION
`sigsize` is of type guint64 and thus should be printed using
`G_GUINT64_FORMAT` instead of `G_GSIZE_FORMAT`.
This led to compilation errors on some systems.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>