### PR TITLE
install: slotstatuspath may not be set when trying to write status file

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -823,6 +823,9 @@ copy:
 		slot_state->status = g_strdup("ok");
 		slot_state->checksum.type = mfimage->checksum.type;
 		slot_state->checksum.digest = g_strdup(mfimage->checksum.digest);
+
+		if (!slotstatuspath)
+			slotstatuspath = g_build_filename(dest_slot->mount_point, "slot.raucs", NULL);
 		
 		g_message("Updating slot file %s", slotstatuspath);
 		install_args_update(args, g_strdup_printf("Updating slot %s status", dest_slot->name));


### PR DESCRIPTION
The variable `slotstatuspath` is initialized after mounting the target
slot when reading the slot status file for checking if we can skip the
update.
If mounting the target slot for reading the slot status path failed
(which is uncritical as it might have been a virgin or broken slot) but
the image update ran successfully and we attempt to write the new status
file, the variable `slotstatuspath` will not be set, yet.

Thus it has to be set after the second mount too in case it is still
NULL.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>