### PR TITLE
fix null buffer issue when extracting signature from bundle

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -299,6 +299,12 @@ gboolean check_bundle(const gchar *bundlename, gsize *size, gboolean verify, GEr
 		goto out;
 	}
 
+	if (sigsize == 0) {
+		g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE,
+				"signature size is 0");
+		res = FALSE;
+		goto out;
+	}
 	/* sanity check: signature should be smaller than bundle size */
 	if (sigsize > (guint64)offset) {
 		g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE,

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -151,9 +151,13 @@ static gboolean input_stream_read_bytes_all(GInputStream *stream,
                                             GCancellable *cancellable,
                                             GError **error)
 {
-	void *buffer = g_malloc0(count);
+	void *buffer = NULL;
 	gsize bytes_read;
 	gboolean res;
+
+	g_assert_cmpint(count, !=, 0);
+
+	buffer = g_malloc0(count);
 
 	res = g_input_stream_read_all(stream, buffer, count, &bytes_read,
 		                      cancellable, error);


### PR DESCRIPTION
Accidently calling rauc with a valid squashfs file but not a valid bundle, could lead to:

``` sh
rauc info /path/to/file.squashfs

(rauc:30892): GLib-GIO-CRITICAL **: g_input_stream_read_all: assertion 'buffer != NULL' failed
(rauc:30892): GLib-CRITICAL **: g_propagate_error: assertion 'src != NULL' failed
(rauc:30892): GLib-CRITICAL **: g_propagate_error: assertion 'src != NULL' failed
Segmentation fault (core dumped)
```