### PR TITLE
Fix test errors with glib 2.49

### DIFF
--- a/include/manifest.h
+++ b/include/manifest.h
@@ -4,6 +4,15 @@
 
 #include <config_file.h>
 
+#define R_MANIFEST_ERROR r_manifest_error_quark ()
+GQuark r_manifest_error_quark (void);
+
+#define R_MANIFEST_ERROR_NO_DATA	0
+#define R_MANIFEST_ERROR_CHECKSUM	1
+#define R_MANIFEST_ERROR_COMPATIBLE	2
+#define R_MANIFEST_PARSE_ERROR 		3
+#define R_MANIFEST_EMPTY_STRING		4
+
 typedef struct {
 	gboolean install_check;
 } InstallHooks;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -10,14 +10,7 @@
 #define RAUC_FILE_PREFIX	"file"
 
 #define R_MANIFEST_ERROR r_manifest_error_quark ()
-
-#define R_MANIFEST_ERROR_NO_DATA	0
-#define R_MANIFEST_ERROR_CHECKSUM	1
-#define R_MANIFEST_ERROR_COMPATIBLE	2
-#define R_MANIFEST_PARSE_ERROR 		3
-#define R_MANIFEST_EMPTY_STRING		4
-
-static GQuark r_manifest_error_quark (void)
+GQuark r_manifest_error_quark (void)
 {
   return g_quark_from_static_string ("r_manifest_error_quark");
 }

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -249,32 +249,28 @@ compatible=SuperBazzer\n\
 
 	data = g_bytes_new_static(MANIFEST2, sizeof(MANIFEST2));
 	g_assert_false(load_manifest_mem(data, &rm, &error));
-	g_assert_nonnull(error);
-	g_assert_cmpstr("Key file does not have key 'compatible'", ==, error->message);
+	g_assert_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND);
 	g_clear_error(&error);
 	g_assert_null(rm);
 	g_clear_pointer(&data, g_byte_array_free);
 
 	data = g_bytes_new_static(MANIFEST3, sizeof(MANIFEST3));
 	g_assert_false(load_manifest_mem(data, &rm, &error));
-	g_assert_nonnull(error);
-	g_assert_cmpstr("Missing value for key 'compatible'", ==, error->message);
+	g_assert_error(error, R_MANIFEST_ERROR, R_MANIFEST_EMPTY_STRING);
 	g_clear_error(&error);
 	g_assert_null(rm);
 	g_clear_pointer(&data, g_byte_array_free);
 
 	data = g_bytes_new_static(MANIFEST4, sizeof(MANIFEST4));
 	g_assert_false(load_manifest_mem(data, &rm, &error));
-	g_assert_nonnull(error);
-	g_assert_cmpstr("Invalid key 'evilkey' in group '[update]'", ==, error->message);
+	g_assert_error(error, R_MANIFEST_ERROR, R_MANIFEST_PARSE_ERROR);
 	g_clear_error(&error);
 	g_assert_null(rm);
 	g_clear_pointer(&data, g_byte_array_free);
 
 	data = g_bytes_new_static(MANIFEST5, sizeof(MANIFEST5));
 	g_assert_false(load_manifest_mem(data, &rm, &error));
-	g_assert_nonnull(error);
-	g_assert_cmpstr("Invalid group '[evilgroup]'", ==, error->message);
+	g_assert_error(error, R_MANIFEST_ERROR, R_MANIFEST_PARSE_ERROR);
 	g_clear_error(&error);
 	g_assert_null(rm);
 	g_clear_pointer(&data, g_byte_array_free);

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -625,19 +625,19 @@ int main(int argc, char *argv[])
 			test_update_handler,
 			update_handler_fixture_tear_down);
 
-	g_test_add("/update_handler/update_handler/ext4_to_ext4/pre-hook/fail",
+	g_test_add("/update_handler/update_handler/tar_to_ext4/pre-hook/fail",
 			UpdateHandlerFixture,
 			&testpair_matrix[28],
 			update_handler_fixture_set_up,
 			test_update_handler,
 			update_handler_fixture_tear_down);
-	g_test_add("/update_handler/update_handler/ext4_to_ext4/pre-hook/fail",
+	g_test_add("/update_handler/update_handler/img_to_raw/pre-hook/fail",
 			UpdateHandlerFixture,
 			&testpair_matrix[29],
 			update_handler_fixture_set_up,
 			test_update_handler,
 			update_handler_fixture_tear_down);
-	g_test_add("/update_handler/update_handler/ext4_to_ext4/pre-hook/fail",
+	g_test_add("/update_handler/update_handler/ext4_to_raw/pre-hook/fail",
 			UpdateHandlerFixture,
 			&testpair_matrix[30],
 			update_handler_fixture_set_up,
@@ -650,19 +650,19 @@ int main(int argc, char *argv[])
 			test_update_handler,
 			update_handler_fixture_tear_down);
 
-	g_test_add("/update_handler/update_handler/ext4_to_ext4/post-hook/fail",
+	g_test_add("/update_handler/update_handler/tar_to_ext4/post-hook/fail",
 			UpdateHandlerFixture,
 			&testpair_matrix[32],
 			update_handler_fixture_set_up,
 			test_update_handler,
 			update_handler_fixture_tear_down);
-	g_test_add("/update_handler/update_handler/ext4_to_ext4/post-hook/fail",
+	g_test_add("/update_handler/update_handler/img_to_raw/post-hook/fail",
 			UpdateHandlerFixture,
 			&testpair_matrix[33],
 			update_handler_fixture_set_up,
 			test_update_handler,
 			update_handler_fixture_tear_down);
-	g_test_add("/update_handler/update_handler/ext4_to_ext4/post-hook/fail",
+	g_test_add("/update_handler/update_handler/ext4_to_raw/post-hook/fail",
 			UpdateHandlerFixture,
 			&testpair_matrix[34],
 			update_handler_fixture_set_up,
@@ -675,19 +675,19 @@ int main(int argc, char *argv[])
 			test_update_handler,
 			update_handler_fixture_tear_down);
 
-	g_test_add("/update_handler/update_handler/ext4_to_ext4/install-hook/fail",
+	g_test_add("/update_handler/update_handler/tar_to_ext4/install-hook/fail",
 			UpdateHandlerFixture,
 			&testpair_matrix[36],
 			update_handler_fixture_set_up,
 			test_update_handler,
 			update_handler_fixture_tear_down);
-	g_test_add("/update_handler/update_handler/ext4_to_ext4/install-hook/fail",
+	g_test_add("/update_handler/update_handler/img_to_raw/install-hook/fail",
 			UpdateHandlerFixture,
 			&testpair_matrix[37],
 			update_handler_fixture_set_up,
 			test_update_handler,
 			update_handler_fixture_tear_down);
-	g_test_add("/update_handler/update_handler/ext4_to_ext4/install-hook/fail",
+	g_test_add("/update_handler/update_handler/ext4_to_raw/install-hook/fail",
 			UpdateHandlerFixture,
 			&testpair_matrix[38],
 			update_handler_fixture_set_up,


### PR DESCRIPTION
This version of glib changed an error message for key-file errors and checks for duplicate test paths. This triggered some errors when running the tests that will be fixed by these two patches.