### PR TITLE
main: print hooks in rauc info

### DIFF
--- a/test/rauc.t
+++ b/test/rauc.t
@@ -66,7 +66,7 @@ test_expect_success "rauc info" "
 
 test_expect_success "rauc info shell" "
   rauc -c $SHARNESS_TEST_DIRECTORY/test.conf --output-format=shell \
-    info $SHARNESS_TEST_DIRECTORY/good-bundle.raucb
+    info $SHARNESS_TEST_DIRECTORY/good-bundle.raucb | sh
 "
 
 test_expect_success JSON "rauc info json" "


### PR DESCRIPTION
This adds support for printing registered bundle and slot hooks when
calling `rauc info` for all available output formats.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>