### PR TITLE
src/install: Explicitly mention that slot was skipped in progress

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -760,8 +760,8 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 				install_args_update(args, g_strdup_printf("Skipping update for correct image %s", mfimage->filename));
 				g_message("Skipping update for correct image %s", mfimage->filename);
 				r_context_end_step("check_slot", TRUE);
-				r_context_begin_step("copy_image", "Copying image", 0);
-				r_context_end_step("copy_image", TRUE);
+				r_context_begin_step("skip_image", "Copying image skipped", 0);
+				r_context_end_step("skip_image", TRUE);
 				goto image_out;
 			} else {
 				g_message("Slot needs to be updated with %s", mfimage->filename);


### PR DESCRIPTION
The progress information for a skipped slot installation was 'Copying
image' so far. To not irritate a Progress log reader, this should be
changed to something clearly indicating that image copying was skipped
as rauc detected that the slot already contains the desired revision.