### PR TITLE
introduce rauc install --ignore-compatible switch

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -32,6 +32,8 @@ typedef struct {
 
 	/* optional custom handler extra arguments */
 	gchar *handlerextra;
+	/* ignore compatible check */
+	gboolean ignore_compatible;
 } RaucContext;
 
 typedef struct {

--- a/src/install.c
+++ b/src/install.c
@@ -378,7 +378,9 @@ out:
 }
 
 static gboolean verify_compatible(RaucManifest *manifest) {
-	if (g_strcmp0(r_context()->config->system_compatible,
+	if (r_context()->ignore_compatible) {
+		return TRUE;
+	} else if (g_strcmp0(r_context()->config->system_compatible,
 		      manifest->update_compatible) == 0) {
 		return TRUE;
 	} else {


### PR DESCRIPTION
This allows to install a bundle with a different compatible, e.g. for
making a generic board with a standard factory image a board with
product-specific rootfs.